### PR TITLE
feat:#60 - add JWT login page and protected routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,24 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { AuthProvider } from "./auth/AuthContext";
+import ProtectedRoute from "./auth/ProtectedRoute";
 import HomePage from "./pages/HomePage.tsx";
 import PlannerPage from "./pages/PlannerPage.tsx";
 import HistoryPage from "./pages/HistoryPage.tsx";
+import LoginPage from "./pages/LoginPage.tsx";
 import "./App.css";
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/planner" element={<PlannerPage />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-          <Route path="/history" element={<HistoryPage />} />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/" element={<ProtectedRoute><HomePage /></ProtectedRoute>} />
+          <Route path="/planner" element={<ProtectedRoute><PlannerPage /></ProtectedRoute>} />
+          <Route path="/history" element={<ProtectedRoute><HistoryPage /></ProtectedRoute>} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   );
 }

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,12 +1,5 @@
-import { createContext, useContext, useState, type ReactNode } from "react";
-
-interface AuthContextType {
-    token: string | null;
-    login: (token: string) => void;
-    logout: () => void;
-}
-
-const AuthContext = createContext<AuthContextType | null>(null);
+import { useState, type ReactNode } from "react";
+import { AuthContext } from "./authContext";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
     const [token, setToken] = useState<string | null>(() =>
@@ -28,15 +21,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             {children}
         </AuthContext.Provider>
     );
-}
-
-export function useAuth(): AuthContextType {
-    const ctx = useContext(AuthContext);
-    if (!ctx) throw new Error("useAuth must be used inside AuthProvider");
-    return ctx;
-}
-
-/** Helper for non-component code (classes, utils) */
-export function getAuthToken(): string | null {
-    return localStorage.getItem("auth_token");
 }

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+interface AuthContextType {
+    token: string | null;
+    login: (token: string) => void;
+    logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [token, setToken] = useState<string | null>(() =>
+        localStorage.getItem("auth_token")
+    );
+
+    const login = (newToken: string) => {
+        localStorage.setItem("auth_token", newToken);
+        setToken(newToken);
+    };
+
+    const logout = () => {
+        localStorage.removeItem("auth_token");
+        setToken(null);
+    };
+
+    return (
+        <AuthContext.Provider value={{ token, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export function useAuth(): AuthContextType {
+    const ctx = useContext(AuthContext);
+    if (!ctx) throw new Error("useAuth must be used inside AuthProvider");
+    return ctx;
+}
+
+/** Helper for non-component code (classes, utils) */
+export function getAuthToken(): string | null {
+    return localStorage.getItem("auth_token");
+}

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { Navigate } from "react-router-dom";
-import { useAuth } from "./AuthContext";
+import { useAuth } from "./useAuth";
 import type { ReactNode } from "react";
 
 export default function ProtectedRoute({ children }: { children: ReactNode }) {

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -1,0 +1,9 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./AuthContext";
+import type { ReactNode } from "react";
+
+export default function ProtectedRoute({ children }: { children: ReactNode }) {
+    const { token } = useAuth();
+    if (!token) return <Navigate to="/login" replace />;
+    return <>{children}</>;
+}

--- a/src/auth/authContext.ts
+++ b/src/auth/authContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+export interface AuthContextType {
+    token: string | null;
+    login: (token: string) => void;
+    logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType | null>(null);

--- a/src/auth/useAuth.ts
+++ b/src/auth/useAuth.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+import { AuthContext, type AuthContextType } from "./authContext";
+
+export function useAuth(): AuthContextType {
+    const ctx = useContext(AuthContext);
+    if (!ctx) throw new Error("useAuth must be used inside AuthProvider");
+    return ctx;
+}
+
+/** Helper for non-component code (classes, utils) */
+export function getAuthToken(): string | null {
+    return localStorage.getItem("auth_token");
+}

--- a/src/components/History/HistoryPage.css
+++ b/src/components/History/HistoryPage.css
@@ -70,6 +70,31 @@ html, body {
     box-shadow: 0 4px 12px rgba(180,88,158,0.3);
 }
 
+.ch-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.ch-btn-logout {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 12px;
+    border: 1.5px solid rgba(165, 45, 120, 0.2);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.82);
+    color: #8c1f65;
+    cursor: pointer;
+    transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.ch-btn-logout:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(44, 18, 60, 0.14);
+    background: rgba(255, 255, 255, 0.94);
+}
+
 .ch-plus, .ch-arrow {
     font-size: 20px;
 }

--- a/src/components/Home/HomeLanding.tsx
+++ b/src/components/Home/HomeLanding.tsx
@@ -1,9 +1,10 @@
-import { ArrowRight, CarFront, FilePlus2, FolderClock, Settings } from "lucide-react";
+import { ArrowRight, CarFront, FilePlus2, FolderClock, LogOut } from "lucide-react";
 import "./HomeLanding.css";
 
 type HomeLandingProps = {
   onCreateNew?: () => void;
   onOpenHistory?: () => void;
+  onLogout?: () => void;
 };
 
 /**
@@ -12,6 +13,7 @@ type HomeLandingProps = {
 export default function HomeLanding({
   onCreateNew,
   onOpenHistory,
+  onLogout,
 }: HomeLandingProps) {
   return (
     <div className="home-landing">
@@ -27,9 +29,10 @@ export default function HomeLanding({
           <button
             type="button"
             className="home-landing__settings"
-            aria-label="Ouvrir les paramètres"
+            aria-label="Se déconnecter"
+            onClick={onLogout}
           >
-            <Settings size={22} strokeWidth={2.4} />
+            <LogOut size={22} strokeWidth={2.4} />
           </button>
         </header>
 

--- a/src/customObject/Itinerary/ItineraryNetModel.ts
+++ b/src/customObject/Itinerary/ItineraryNetModel.ts
@@ -15,9 +15,18 @@ import type {
 import {TimeSpan} from "../TimeSpan.ts";
 import type {Feature, LineString} from "geojson";
 import {updateStarts} from "./utils.ts";
+import {getAuthToken} from "../../auth/AuthContext.tsx";
 
 
 const BACKEND_URL: string = "http://localhost:8080"
+
+function authHeaders(): HeadersInit {
+    const token = getAuthToken();
+    return {
+        "Content-Type": "application/json",
+        ...(token ? { "Authorization": `Bearer ${token}` } : {}),
+    };
+}
 
 export class ItineraryNetModel {
     // Attributs
@@ -59,9 +68,7 @@ export class ItineraryNetModel {
         }
         const response: Response = await fetch(BACKEND_URL + `/tours/${itinerary.id}`, {
             method: "PUT",
-            headers: {
-                "Content-Type": "application/json"
-            },
+            headers: authHeaders(),
             body: JSON.stringify(request),
         });
 
@@ -88,9 +95,7 @@ export class ItineraryNetModel {
 
         const response: Response = await fetch(BACKEND_URL + `/tours`, {
             method: "POST",
-            headers: {
-                "Content-Type": "application/json"
-            },
+            headers: authHeaders(),
             body: JSON.stringify(request),
         })
 
@@ -135,9 +140,7 @@ export class ItineraryNetModel {
     private async retrieveItinerary(id: number): Promise<ItineraryResponse> {
         const response: Response = await fetch(BACKEND_URL + `/tours/${id}`, {
             method: "GET",
-            headers: {
-                "Content-Type": "application/json"
-            }
+            headers: authHeaders(),
         });
 
         if (!response.ok) {

--- a/src/customObject/Itinerary/ItineraryNetModel.ts
+++ b/src/customObject/Itinerary/ItineraryNetModel.ts
@@ -15,7 +15,7 @@ import type {
 import {TimeSpan} from "../TimeSpan.ts";
 import type {Feature, LineString} from "geojson";
 import {updateStarts} from "./utils.ts";
-import {getAuthToken} from "../../auth/AuthContext.tsx";
+import {getAuthToken} from "../../auth/useAuth";
 
 
 const BACKEND_URL: string = "http://localhost:8080"

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { LogOut } from 'lucide-react';
 import { ItineraryCard } from '../components/History/ItineraryCard';
 import type { ItineraryResponse } from '../customObject/Itinerary/netTypes';
 import { itineraryModel } from '../customObject/Itinerary/ItineraryStore';
-import { getAuthToken } from '../auth/AuthContext';
+import { getAuthToken, useAuth } from '../auth/AuthContext';
 import '../components/History/HistoryPage.css';
 
 const BACKEND_URL = "http://localhost:8080";
@@ -15,6 +16,7 @@ function authHeaders(): HeadersInit {
 
 export default function HistoryPage() {
     const navigate = useNavigate();
+    const { logout } = useAuth();
     const [itineraries, setItineraries] = useState<ItineraryResponse[]>([]);
     const [filtered, setFiltered] = useState<ItineraryResponse[]>([]);
     const [search, setSearch] = useState('');
@@ -70,6 +72,11 @@ export default function HistoryPage() {
         }
     };
 
+    const handleLogout = () => {
+        logout();
+        navigate("/login", { replace: true });
+    };
+
     const handleCreateNew = () => {
         itineraryModel.reset();
         navigate('/planner');
@@ -89,11 +96,16 @@ export default function HistoryPage() {
                     <span className="ch-logo">🚗</span>
                     <h1 className="ch-brand-title">C15 FIESTA TOUR</h1>
                 </div>
-                <button className="ch-btn-new" onClick={handleCreateNew}>
-                    <span className="ch-plus">+</span>
-                    Nouveau convoi
-                    <span className="ch-arrow">›</span>
-                </button>
+                <div className="ch-header-actions">
+                    <button className="ch-btn-new" onClick={handleCreateNew}>
+                        <span className="ch-plus">+</span>
+                        Nouveau convoi
+                        <span className="ch-arrow">›</span>
+                    </button>
+                    <button className="ch-btn-logout" onClick={handleLogout} aria-label="Se déconnecter">
+                        <LogOut size={18} strokeWidth={2.4} />
+                    </button>
+                </div>
             </header>
 
             <main className="ch-content">

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -4,7 +4,7 @@ import { LogOut } from 'lucide-react';
 import { ItineraryCard } from '../components/History/ItineraryCard';
 import type { ItineraryResponse } from '../customObject/Itinerary/netTypes';
 import { itineraryModel } from '../customObject/Itinerary/ItineraryStore';
-import { getAuthToken, useAuth } from '../auth/AuthContext';
+import { getAuthToken, useAuth } from '../auth/useAuth';
 import '../components/History/HistoryPage.css';
 
 const BACKEND_URL = "http://localhost:8080";

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -3,9 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import { ItineraryCard } from '../components/History/ItineraryCard';
 import type { ItineraryResponse } from '../customObject/Itinerary/netTypes';
 import { itineraryModel } from '../customObject/Itinerary/ItineraryStore';
+import { getAuthToken } from '../auth/AuthContext';
 import '../components/History/HistoryPage.css';
 
 const BACKEND_URL = "http://localhost:8080";
+
+function authHeaders(): HeadersInit {
+    const token = getAuthToken();
+    return token ? { "Authorization": `Bearer ${token}` } : {};
+}
 
 export default function HistoryPage() {
     const navigate = useNavigate();
@@ -18,7 +24,7 @@ export default function HistoryPage() {
     const loadItineraries = useCallback(async () => {
         try {
             setLoading(true);
-            const res = await fetch(`${BACKEND_URL}/tours`);
+            const res = await fetch(`${BACKEND_URL}/tours`, { headers: authHeaders() });
             if (!res.ok) throw new Error('Backend error');
             const data: ItineraryResponse[] = await res.json();
             setItineraries(data);
@@ -57,7 +63,7 @@ export default function HistoryPage() {
     const handleDelete = async (id: number) => {
         if (!confirm('Supprimer ce convoi ?')) return;
         try {
-            await fetch(`${BACKEND_URL}/tours/${id}`, { method: 'DELETE' });
+            await fetch(`${BACKEND_URL}/tours/${id}`, { method: 'DELETE', headers: authHeaders() });
             setItineraries(prev => prev.filter(i => i.id !== id));
         } catch (err) {
             console.error('Erreur suppression:', err);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import HomeLanding from "../components/Home/HomeLanding.tsx";
 import {itineraryModel} from "../customObject/Itinerary/ItineraryStore.ts";
-import { useAuth } from "../auth/AuthContext";
+import { useAuth } from "../auth/useAuth";
 
 export default function HomePage() {
   const navigate = useNavigate();

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,9 +1,16 @@
 import { useNavigate } from "react-router-dom";
 import HomeLanding from "../components/Home/HomeLanding.tsx";
 import {itineraryModel} from "../customObject/Itinerary/ItineraryStore.ts";
+import { useAuth } from "../auth/AuthContext";
 
 export default function HomePage() {
   const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate("/login", { replace: true });
+  };
 
   return (
     <HomeLanding
@@ -12,6 +19,7 @@ export default function HomePage() {
         navigate("/planner")
       }}
       onOpenHistory={() => navigate("/history")}
+      onLogout={handleLogout}
     />
   );
 }

--- a/src/pages/LoginPage.css
+++ b/src/pages/LoginPage.css
@@ -1,0 +1,184 @@
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Baloo+2:wght@600;700&display=swap");
+
+.login-page {
+    position: relative;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(18px, 4vw, 36px);
+    overflow: hidden;
+    background: radial-gradient(120% 120% at 20% 18%, #fff 0%, #f7f0fa 55%, #eef4ff 100%);
+    color: #2f1f38;
+}
+
+.login-page::before {
+    content: "";
+    position: absolute;
+    inset: -4%;
+    background: url("/home-photo.jpg") center center / cover no-repeat;
+    filter: blur(3px) brightness(0.97) saturate(1.02) opacity(0.9);
+    z-index: 0;
+}
+
+.login-page::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(70% 60% at 10% 10%, rgba(165, 45, 120, 0.06), transparent 60%),
+        radial-gradient(80% 80% at 90% 20%, rgba(255, 255, 255, 0.6), transparent 70%),
+        linear-gradient(180deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0.08) 34%, rgba(255, 255, 255, 0.04) 100%);
+    z-index: 0;
+}
+
+.login-card {
+    position: relative;
+    z-index: 1;
+    width: min(420px, 100%);
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(165, 45, 120, 0.1);
+    border-radius: 24px;
+    padding: clamp(28px, 5vw, 44px) clamp(24px, 5vw, 40px);
+    box-shadow: 0 24px 48px rgba(44, 18, 60, 0.22);
+    backdrop-filter: blur(10px);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.login-card__brand {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    font-family: "Baloo 2", "Manrope", system-ui, -apple-system, sans-serif;
+    font-size: clamp(18px, 2vw, 22px);
+    font-weight: 800;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: #8c1f65;
+}
+
+.login-card__brand-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(165, 45, 120, 0.16), rgba(165, 45, 120, 0.04));
+    color: #8c1f65;
+}
+
+.login-card__heading {
+    text-align: center;
+}
+
+.login-card__title {
+    margin: 0 0 6px;
+    font-size: clamp(20px, 2.5vw, 24px);
+    font-weight: 800;
+    color: #2f1f38;
+}
+
+.login-card__subtitle {
+    margin: 0;
+    font-size: 14px;
+    color: #7a6b86;
+}
+
+.login-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.login-form__field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.login-form__label {
+    font-size: 13px;
+    font-weight: 600;
+    color: #2f1f38;
+    letter-spacing: 0.2px;
+}
+
+.login-form__input {
+    padding: 12px 16px;
+    border: 1.5px solid rgba(165, 45, 120, 0.2);
+    border-radius: 12px;
+    font-family: "Manrope", system-ui, -apple-system, sans-serif;
+    font-size: 15px;
+    color: #2f1f38;
+    background: rgba(255, 255, 255, 0.8);
+    outline: none;
+    transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.login-form__input::placeholder {
+    color: #7a6b86;
+}
+
+.login-form__input:focus {
+    border-color: #a52d78;
+    box-shadow: 0 0 0 3px rgba(165, 45, 120, 0.12);
+}
+
+.login-form__input--error {
+    border-color: #c0392b;
+    box-shadow: 0 0 0 3px rgba(192, 57, 43, 0.1);
+}
+
+.login-form__error {
+    padding: 12px 16px;
+    border-radius: 12px;
+    background: rgba(192, 57, 43, 0.08);
+    border: 1px solid rgba(192, 57, 43, 0.2);
+    color: #c0392b;
+    font-size: 14px;
+    font-weight: 500;
+    text-align: center;
+}
+
+.login-form__submit {
+    margin-top: 4px;
+    padding: 14px 24px;
+    background: linear-gradient(135deg, #b1347d 0%, #c84e95 100%);
+    color: #fff;
+    border: none;
+    border-radius: 14px;
+    font-family: "Manrope", system-ui, -apple-system, sans-serif;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: 0 8px 24px rgba(175, 57, 129, 0.32);
+    transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.login-form__submit:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 32px rgba(175, 57, 129, 0.44);
+}
+
+.login-form__submit:active:not(:disabled) {
+    transform: translateY(0);
+}
+
+.login-form__submit:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+@media (max-width: 460px) {
+    .login-page::before {
+        filter: blur(6px) opacity(0.32);
+    }
+
+    .login-card {
+        border-radius: 18px;
+    }
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { Map } from "lucide-react";
-import { useAuth } from "../auth/AuthContext";
+import { useAuth } from "../auth/useAuth";
 import "./LoginPage.css";
 
 const BACKEND_URL = "http://localhost:8080";

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,106 @@
+import { useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { Map } from "lucide-react";
+import { useAuth } from "../auth/AuthContext";
+import "./LoginPage.css";
+
+const BACKEND_URL = "http://localhost:8080";
+
+export default function LoginPage() {
+    const { login } = useAuth();
+    const navigate = useNavigate();
+
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        setError(null);
+        setLoading(true);
+
+        try {
+            const res = await fetch(`${BACKEND_URL}/auth/login`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ username, password }),
+            });
+
+            if (!res.ok) {
+                setError("Identifiants incorrects. Veuillez réessayer.");
+                return;
+            }
+
+            const data = await res.json();
+            login(data.token);
+            navigate("/", { replace: true });
+        } catch {
+            setError("Impossible de joindre le serveur. Vérifiez votre connexion.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="login-page">
+            <div className="login-card">
+                <div className="login-card__brand">
+                    <span className="login-card__brand-icon">
+                        <Map size={22} />
+                    </span>
+                    <span>C15 Fiesta Tour</span>
+                </div>
+
+                <div className="login-card__heading">
+                    <h1 className="login-card__title">Connexion</h1>
+                    <p className="login-card__subtitle">Accédez à votre espace de planification</p>
+                </div>
+
+                <form className="login-form" onSubmit={handleSubmit}>
+                    <div className="login-form__field">
+                        <label className="login-form__label" htmlFor="username">
+                            Identifiant
+                        </label>
+                        <input
+                            id="username"
+                            type="text"
+                            className={`login-form__input${error ? " login-form__input--error" : ""}`}
+                            placeholder="Votre identifiant"
+                            value={username}
+                            onChange={(e) => setUsername(e.target.value)}
+                            autoComplete="username"
+                            required
+                        />
+                    </div>
+
+                    <div className="login-form__field">
+                        <label className="login-form__label" htmlFor="password">
+                            Mot de passe
+                        </label>
+                        <input
+                            id="password"
+                            type="password"
+                            className={`login-form__input${error ? " login-form__input--error" : ""}`}
+                            placeholder="Votre mot de passe"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            autoComplete="current-password"
+                            required
+                        />
+                    </div>
+
+                    {error && <p className="login-form__error">{error}</p>}
+
+                    <button
+                        type="submit"
+                        className="login-form__submit"
+                        disabled={loading}
+                    >
+                        {loading ? "Connexion en cours…" : "Se connecter"}
+                    </button>
+                </form>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
  ## Description

  Mise en place de l'authentification côté frontend, en lien avec le système JWT déjà en place sur le backend (`POST /auth/login`).

  ## Changements

  - **`src/auth/AuthContext.tsx`** — Contexte React gérant le token JWT : stockage dans le `localStorage`, exposition des méthodes `login()` /
  `logout()`, et helper `getAuthToken()` utilisable hors composant.
  - **`src/auth/ProtectedRoute.tsx`** — Composant de garde qui redirige vers `/login` si aucun token n'est présent.
  - **`src/pages/LoginPage.tsx`** — Page de connexion appelant `POST /auth/login` avec identifiant et mot de passe, cohérente graphiquement avec le
   reste de l'application.
  - **`src/pages/LoginPage.css`** — Styles de la page de connexion (fond carte floutée, couleurs de marque, typographies Manrope / Baloo 2).
  - **`src/App.tsx`** — Ajout du provider `AuthProvider`, de la route `/login`, et protection des routes `/`, `/planner` et `/history`.
  - **`src/customObject/Itinerary/ItineraryNetModel.ts`** — Injection automatique du header `Authorization: Bearer <token>` sur tous les appels
  API.
  - **`src/pages/HistoryPage.tsx`** — Idem pour les appels `GET /tours` et `DELETE /tours/:id`.

  ## Comportement

  1. Un utilisateur non authentifié est systématiquement redirigé vers `/login`.
  2. Après connexion, le token est stocké en `localStorage` et envoyé sur chaque requête vers le backend.
  3. La déconnexion supprime le token et redirige vers `/login`.