### PR TITLE
feat: skip route recalculation during drag, compute immediately on drop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,22 +20,74 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/geojson": "^7946.0.16",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.1.4",
         "babel-plugin-react-compiler": "^1.0.0",
         "baseline-browser-mapping": "^2.9.19",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.0.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -225,13 +277,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -272,6 +324,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -307,9 +369,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -318,6 +380,171 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -987,6 +1214,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1424,6 +1669,110 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1468,6 +1817,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1528,6 +1895,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1824,6 +2192,151 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1865,6 +2378,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1887,6 +2410,45 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-plugin-react-compiler": {
       "version": "1.0.0",
@@ -1913,6 +2475,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1992,6 +2564,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2058,12 +2640,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2083,10 +2700,34 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2096,6 +2737,26 @@
       "integrity": "sha512-DrqJ11Knd+lo+dv+lltvfMDLU27g14LMdH2b0O3Pio4uk0x+z7OR+JrmyacTPN2M8w3BrZ7/RTwG3R9B7irPlg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2337,6 +2998,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2345,6 +3016,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2522,6 +3203,26 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2559,6 +3260,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2582,12 +3293,58 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2607,6 +3364,58 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2729,6 +3538,84 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2780,6 +3667,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2845,6 +3743,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2864,6 +3775,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2925,6 +3843,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2957,6 +3903,13 @@
       "peerDependencies": {
         "react": "^19.2.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -3014,6 +3967,30 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3066,6 +4043,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3105,6 +4095,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3113,6 +4110,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3141,6 +4165,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3156,6 +4204,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3227,6 +4331,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3353,6 +4467,145 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3369,6 +4622,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3378,6 +4648,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -22,20 +25,26 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/geojson": "^7946.0.16",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.1.4",
     "babel-plugin-react-compiler": "^1.0.0",
     "baseline-browser-mapping": "^2.9.19",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.0.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -1,7 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { AuthProvider } from './AuthContext';
 import { useAuth } from './useAuth';
 

--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { AuthProvider } from './AuthContext';
+import { useAuth } from './useAuth';
+
+// Composant de test pour accéder au contexte
+function TestConsumer() {
+  const { token, login, logout } = useAuth();
+  return (
+    <div>
+      <span data-testid="token">{token ?? 'null'}</span>
+      <button onClick={() => login('test-token')}>Login</button>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('initialise token à null si localStorage vide', () => {
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    expect(screen.getByTestId('token').textContent).toBe('null');
+  });
+
+  it('initialise token depuis localStorage', () => {
+    localStorage.setItem('auth_token', 'stored-token');
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    expect(screen.getByTestId('token').textContent).toBe('stored-token');
+  });
+
+  it('login() stocke le token et met à jour l\'état', async () => {
+    const user = userEvent.setup();
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    await user.click(screen.getByText('Login'));
+    expect(screen.getByTestId('token').textContent).toBe('test-token');
+    expect(localStorage.getItem('auth_token')).toBe('test-token');
+  });
+
+  it('logout() supprime le token et met à jour l\'état', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('auth_token', 'existing-token');
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    await user.click(screen.getByText('Logout'));
+    expect(screen.getByTestId('token').textContent).toBe('null');
+    expect(localStorage.getItem('auth_token')).toBeNull();
+  });
+
+  it('renvoie les enfants correctement', () => {
+    render(
+      <AuthProvider>
+        <span data-testid="child">enfant</span>
+      </AuthProvider>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});
+
+describe('useAuth()', () => {
+  it('lance une erreur si utilisé hors AuthProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => {
+      render(<TestConsumer />);
+    }).toThrow('useAuth must be used inside AuthProvider');
+    spy.mockRestore();
+  });
+});

--- a/src/auth/useAuth.test.ts
+++ b/src/auth/useAuth.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getAuthToken } from './useAuth';
+
+describe('getAuthToken()', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('renvoie null si aucun token stocké', () => {
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it('renvoie le token si présent dans localStorage', () => {
+    localStorage.setItem('auth_token', 'mon-token-jwt');
+    expect(getAuthToken()).toBe('mon-token-jwt');
+  });
+
+  it('renvoie null après suppression du token', () => {
+    localStorage.setItem('auth_token', 'token');
+    localStorage.removeItem('auth_token');
+    expect(getAuthToken()).toBeNull();
+  });
+
+  it('renvoie la valeur mise à jour si le token change', () => {
+    localStorage.setItem('auth_token', 'ancien-token');
+    localStorage.setItem('auth_token', 'nouveau-token');
+    expect(getAuthToken()).toBe('nouveau-token');
+  });
+});

--- a/src/components/Panels/DragNDrop/DragNDropUtils.test.ts
+++ b/src/components/Panels/DragNDrop/DragNDropUtils.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Casser la dépendance circulaire avant toute importation de DragNDropUtils
+vi.mock('../../../customObject/Itinerary/ItineraryStore', () => ({
+  createItineraryStore: vi.fn(() => ({
+    getSnapshot: vi.fn(),
+    subscribe: vi.fn(() => vi.fn()),
+    set: vi.fn(),
+  })),
+}));
+vi.mock('../../../customObject/Itinerary/ItineraryNetModel', () => ({
+  ItineraryNetModel: class MockItineraryNetModel {
+    timeoutID = -1;
+    store = null;
+    setupSave() {}
+    async put() { return true; }
+    async post() { return true; }
+    async get() { return undefined; }
+  },
+}));
+vi.mock('../../../auth/useAuth', () => ({
+  getAuthToken: vi.fn(() => null),
+}));
+
+import { getActiveItem, getActiveCat, reorderSegment, reorderItems } from './DragNDropUtils';
+import { TimeSpan } from '../../../customObject/TimeSpan';
+import type { Segment, Step, Itinerary } from '../../../customObject/Itinerary/types';
+import type { Active, Over } from '@dnd-kit/core';
+
+// Helpers
+function makeStep(id: string, isDefaultSegStart = false): Step {
+  return {
+    id,
+    content: { title: id, duration: new TimeSpan() },
+    isDefaultSegStart,
+  };
+}
+
+function makeSegment(id: string, steps: Step[] = [], isStartEnd = false): Segment {
+  return {
+    id,
+    content: {
+      title: id,
+      hour: new Date(),
+      duration: new TimeSpan(),
+      distance: 0,
+    },
+    isStartEnd,
+    steps,
+  };
+}
+
+function makeActive(id: string, categoryId?: string): Active {
+  return {
+    id,
+    data: { current: categoryId ? { categoryId } : undefined },
+  } as unknown as Active;
+}
+
+function makeOver(id: string, categoryId?: string): Over {
+  return {
+    id,
+    data: { current: categoryId ? { categoryId } : undefined },
+  } as unknown as Over;
+}
+
+function makeItinerary(segments: Segment[]): Itinerary {
+  return {
+    id: 1,
+    name: 'Test',
+    totalDuration: new TimeSpan(),
+    totalDistance: 0,
+    segments,
+  };
+}
+
+describe('getActiveItem()', () => {
+  it('renvoie l\'étape correspondante', () => {
+    const step = makeStep('step-1');
+    const seg = makeSegment('seg-1', [step]);
+    const active = makeActive('step-1', 'seg-1');
+    const result = getActiveItem(active, [seg]);
+    expect(result?.id).toBe('step-1');
+  });
+
+  it('renvoie undefined si categoryId absent', () => {
+    const active = makeActive('step-1', undefined);
+    expect(getActiveItem(active, [])).toBeUndefined();
+  });
+
+  it('renvoie undefined si la catégorie n\'existe pas', () => {
+    const active = makeActive('step-1', 'ghost-seg');
+    expect(getActiveItem(active, [makeSegment('seg-1')])).toBeUndefined();
+  });
+
+  it('renvoie undefined si l\'étape n\'existe pas dans la catégorie', () => {
+    const seg = makeSegment('seg-1', [makeStep('other')]);
+    const active = makeActive('ghost-step', 'seg-1');
+    expect(getActiveItem(active, [seg])).toBeUndefined();
+  });
+});
+
+describe('getActiveCat()', () => {
+  it('renvoie le segment correspondant', () => {
+    const seg = makeSegment('seg-1');
+    const active = makeActive('seg-1');
+    const result = getActiveCat(active, [seg]);
+    expect(result?.id).toBe('seg-1');
+  });
+
+  it('renvoie undefined si le segment n\'existe pas', () => {
+    const active = makeActive('ghost');
+    expect(getActiveCat(active, [makeSegment('seg-1')])).toBeUndefined();
+  });
+});
+
+describe('reorderSegment()', () => {
+  it('appelle itineraryModel.reorderSegment avec l\'index correct', () => {
+    const segs = [makeSegment('start'), makeSegment('seg-a'), makeSegment('end')];
+    const itinerary = makeItinerary(segs);
+    const model = { reorderSegment: vi.fn() } as any;
+    const active = makeActive('seg-a');
+    const over = makeOver('end');
+    reorderSegment(itinerary, model, active, over);
+    expect(model.reorderSegment).toHaveBeenCalledWith('seg-a', 2);
+  });
+});
+
+describe('reorderItems()', () => {
+  it('ne fait rien si srcCategory absent', () => {
+    const model = { reorderStep: vi.fn() } as any;
+    const active = makeActive('step-1', undefined); // pas de categoryId
+    const over = makeOver('step-2', 'seg-1');
+    reorderItems(makeItinerary([]), model, active, over);
+    expect(model.reorderStep).not.toHaveBeenCalled();
+  });
+
+  it('ne fait rien si le segment source est un segment start/end', () => {
+    const step = makeStep('step-1');
+    const startSeg = makeSegment('start', [step], true);
+    const over = makeOver('step-1', 'start');
+    const active = makeActive('step-1', 'start');
+    const model = { reorderStep: vi.fn() } as any;
+    reorderItems(makeItinerary([startSeg]), model, active, over);
+    expect(model.reorderStep).not.toHaveBeenCalled();
+  });
+
+  it('ne fait rien si l\'étape est un départ par défaut', () => {
+    const defaultStep = makeStep('default-step', true);
+    const step2 = makeStep('step-2');
+    const seg = makeSegment('seg-a', [defaultStep, step2]);
+    const active = makeActive('default-step', 'seg-a');
+    const over = makeOver('step-2', 'seg-a');
+    const model = { reorderStep: vi.fn() } as any;
+    reorderItems(makeItinerary([seg]), model, active, over);
+    expect(model.reorderStep).not.toHaveBeenCalled();
+  });
+
+  it('appelle reorderStep pour un déplacement valide dans le même segment', () => {
+    const s1 = makeStep('step-1');
+    const s2 = makeStep('step-2');
+    const seg = makeSegment('seg-a', [s1, s2]);
+    const itinerary = makeItinerary([seg]);
+    const model = { reorderStep: vi.fn() } as any;
+    const active = makeActive('step-1', 'seg-a');
+    const over = makeOver('step-2', 'seg-a');
+    reorderItems(itinerary, model, active, over);
+    expect(model.reorderStep).toHaveBeenCalledWith('seg-a', 0, 'seg-a', 1);
+  });
+
+  it('appelle reorderStep pour un déplacement entre deux segments', () => {
+    const s1 = makeStep('step-1');
+    const s2 = makeStep('step-2');
+    const segA = makeSegment('seg-a', [s1]);
+    const segB = makeSegment('seg-b', [s2]);
+    const itinerary = makeItinerary([segA, segB]);
+    const model = { reorderStep: vi.fn() } as any;
+    const active = makeActive('step-1', 'seg-a');
+    const over = makeOver('step-2', 'seg-b');
+    reorderItems(itinerary, model, active, over);
+    expect(model.reorderStep).toHaveBeenCalledWith('seg-a', 0, 'seg-b', 0);
+  });
+});

--- a/src/components/Panels/DragNDrop/DragNDropUtils.test.ts
+++ b/src/components/Panels/DragNDrop/DragNDropUtils.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../../auth/useAuth', () => ({
 
 import { getActiveItem, getActiveCat, reorderSegment, reorderItems } from './DragNDropUtils';
 import { TimeSpan } from '../../../customObject/TimeSpan';
+import type ItineraryModel from '../../../customObject/Itinerary/ItineraryModel';
 import type { Segment, Step, Itinerary } from '../../../customObject/Itinerary/types';
 import type { Active, Over } from '@dnd-kit/core';
 
@@ -118,7 +119,7 @@ describe('reorderSegment()', () => {
   it('appelle itineraryModel.reorderSegment avec l\'index correct', () => {
     const segs = [makeSegment('start'), makeSegment('seg-a'), makeSegment('end')];
     const itinerary = makeItinerary(segs);
-    const model = { reorderSegment: vi.fn() } as any;
+    const model = { reorderSegment: vi.fn() } as unknown as ItineraryModel;
     const active = makeActive('seg-a');
     const over = makeOver('end');
     reorderSegment(itinerary, model, active, over);
@@ -128,7 +129,7 @@ describe('reorderSegment()', () => {
 
 describe('reorderItems()', () => {
   it('ne fait rien si srcCategory absent', () => {
-    const model = { reorderStep: vi.fn() } as any;
+    const model = { reorderStep: vi.fn() } as unknown as ItineraryModel;
     const active = makeActive('step-1', undefined); // pas de categoryId
     const over = makeOver('step-2', 'seg-1');
     reorderItems(makeItinerary([]), model, active, over);
@@ -140,7 +141,7 @@ describe('reorderItems()', () => {
     const startSeg = makeSegment('start', [step], true);
     const over = makeOver('step-1', 'start');
     const active = makeActive('step-1', 'start');
-    const model = { reorderStep: vi.fn() } as any;
+    const model = { reorderStep: vi.fn() } as unknown as ItineraryModel;
     reorderItems(makeItinerary([startSeg]), model, active, over);
     expect(model.reorderStep).not.toHaveBeenCalled();
   });
@@ -151,7 +152,7 @@ describe('reorderItems()', () => {
     const seg = makeSegment('seg-a', [defaultStep, step2]);
     const active = makeActive('default-step', 'seg-a');
     const over = makeOver('step-2', 'seg-a');
-    const model = { reorderStep: vi.fn() } as any;
+    const model = { reorderStep: vi.fn() } as unknown as ItineraryModel;
     reorderItems(makeItinerary([seg]), model, active, over);
     expect(model.reorderStep).not.toHaveBeenCalled();
   });
@@ -161,7 +162,7 @@ describe('reorderItems()', () => {
     const s2 = makeStep('step-2');
     const seg = makeSegment('seg-a', [s1, s2]);
     const itinerary = makeItinerary([seg]);
-    const model = { reorderStep: vi.fn() } as any;
+    const model = { reorderStep: vi.fn() } as unknown as ItineraryModel;
     const active = makeActive('step-1', 'seg-a');
     const over = makeOver('step-2', 'seg-a');
     reorderItems(itinerary, model, active, over);
@@ -174,7 +175,7 @@ describe('reorderItems()', () => {
     const segA = makeSegment('seg-a', [s1]);
     const segB = makeSegment('seg-b', [s2]);
     const itinerary = makeItinerary([segA, segB]);
-    const model = { reorderStep: vi.fn() } as any;
+    const model = { reorderStep: vi.fn() } as unknown as ItineraryModel;
     const active = makeActive('step-1', 'seg-a');
     const over = makeOver('step-2', 'seg-b');
     reorderItems(itinerary, model, active, over);

--- a/src/components/Panels/DragNDrop/UseDragNDrop.tsx
+++ b/src/components/Panels/DragNDrop/UseDragNDrop.tsx
@@ -35,11 +35,13 @@ export function useDragNDrop(): DndProps {
             const item: Step | undefined = getActiveItem(active, itinerary.segments);
             if (item && !item.isDefaultSegStart) {
                 setActiveItem(item);
+                itineraryModel.netModel.startDrag();
             }
         } else if (type === "category") {
             const category: Segment | undefined = getActiveCat(active, itinerary.segments);
             if (category && !category.isStartEnd) {
                 setActiveCat(category);
+                itineraryModel.netModel.startDrag();
             }
         }
     }
@@ -75,6 +77,7 @@ export function useDragNDrop(): DndProps {
         setActiveItem(null);
         setActiveCat(null);
         handleDragMove(event);
+        itineraryModel.netModel.endDrag();
     }
 
     return ({

--- a/src/customObject/DeleteMod/DeleteModStore.test.ts
+++ b/src/customObject/DeleteMod/DeleteModStore.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { deleteModStore } from './DeleteModStore';
+
+// Le store est un singleton — on réinitialise entre les tests
+beforeEach(() => {
+  deleteModStore.set(() => false);
+});
+
+describe('deleteModStore (singleton)', () => {
+  it('getSnapshot() renvoie false par défaut', () => {
+    expect(deleteModStore.getSnapshot()).toBe(false);
+  });
+
+  it('set() met à jour la valeur à true', () => {
+    deleteModStore.set(() => true);
+    expect(deleteModStore.getSnapshot()).toBe(true);
+  });
+
+  it('set() reçoit la valeur précédente et peut la toggler', () => {
+    deleteModStore.set(prev => !prev);
+    expect(deleteModStore.getSnapshot()).toBe(true);
+    deleteModStore.set(prev => !prev);
+    expect(deleteModStore.getSnapshot()).toBe(false);
+  });
+
+  it('set() notifie tous les listeners', () => {
+    const l1 = vi.fn();
+    const l2 = vi.fn();
+    deleteModStore.subscribe(l1);
+    deleteModStore.subscribe(l2);
+    deleteModStore.set(() => true);
+    expect(l1).toHaveBeenCalledOnce();
+    expect(l2).toHaveBeenCalledOnce();
+  });
+
+  it('subscribe() retourne une fonction de désabonnement', () => {
+    const listener = vi.fn();
+    const unsub = deleteModStore.subscribe(listener);
+    unsub();
+    deleteModStore.set(() => true);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('après désabonnement d\'un listener les autres sont encore notifiés', () => {
+    const l1 = vi.fn();
+    const l2 = vi.fn();
+    const unsub1 = deleteModStore.subscribe(l1);
+    deleteModStore.subscribe(l2);
+    unsub1();
+    deleteModStore.set(() => true);
+    expect(l1).not.toHaveBeenCalled();
+    expect(l2).toHaveBeenCalledOnce();
+  });
+});

--- a/src/customObject/Itinerary/ItineraryModel.test.ts
+++ b/src/customObject/Itinerary/ItineraryModel.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ItineraryModel from './ItineraryModel';
+import { TimeSpan } from '../TimeSpan';
+import type { Itinerary, Segment, Step } from './types';
+
+// Mock ItineraryStore pour casser la dépendance circulaire
+// (ItineraryStore.ts crée une instance d'ItineraryModel au niveau module)
+vi.mock('./ItineraryStore', () => {
+  function createItineraryStore(initial?: any) {
+    let itinerary: any = initial ?? {
+      id: -1,
+      name: 'Nouveau Convoi',
+      totalDuration: { _duration: 0 },
+      totalDistance: 0,
+      segments: [],
+    };
+    const listeners = new Set<() => void>();
+    return {
+      getSnapshot: () => itinerary,
+      subscribe: (l: () => void) => {
+        listeners.add(l);
+        return () => listeners.delete(l);
+      },
+      set(updater: (prev: any) => any) {
+        itinerary = updater(itinerary);
+        listeners.forEach(l => l());
+      },
+    };
+  }
+  return { createItineraryStore };
+});
+
+// Mock ItineraryNetModel pour éviter les appels réseau
+vi.mock('./ItineraryNetModel', () => ({
+  ItineraryNetModel: class MockItineraryNetModel {
+    timeoutID = -1;
+    store = null;
+    setupSave() {}
+    async put() { return true; }
+    async post() { return true; }
+    async get() { return undefined; }
+  },
+}));
+
+// Mock getAuthToken
+vi.mock('../../auth/useAuth', () => ({
+  getAuthToken: vi.fn(() => null),
+}));
+
+// Import createItineraryStore après les mocks pour les tests qui en ont besoin
+import { createItineraryStore } from './ItineraryStore';
+
+// Helpers
+function makeStep(id: string, title = id, hasLocation = false): Step {
+  return {
+    id,
+    content: {
+      title,
+      duration: new TimeSpan(),
+      ...(hasLocation ? { location: { lat: 1, lon: 2 } } : {}),
+    },
+    isDefaultSegStart: false,
+  };
+}
+
+function makeSegment(id: string, steps: Step[] = [], durationMs = 0): Segment {
+  return {
+    id,
+    content: {
+      title: id,
+      hour: new Date('2024-01-01T08:00:00Z'),
+      duration: new TimeSpan(durationMs),
+      distance: 0,
+    },
+    isStartEnd: false,
+    steps,
+  };
+}
+
+function createModel(initial?: Partial<Itinerary>): ItineraryModel {
+  const base: Itinerary = {
+    id: -1,
+    name: 'Test',
+    totalDuration: new TimeSpan(),
+    totalDistance: 0,
+    segments: [],
+    ...initial,
+  };
+  return new ItineraryModel({ initial: base });
+}
+
+describe('ItineraryModel', () => {
+  describe('constructor', () => {
+    it('se construit sans arguments et crée start/end', () => {
+      const model = new ItineraryModel({});
+      const route = model.route;
+      expect(route.segments.some(s => s.id === 'start')).toBe(true);
+      expect(route.segments.some(s => s.id === 'end')).toBe(true);
+    });
+
+    it('se construit avec un store existant', () => {
+      const store = createItineraryStore();
+      const model = new ItineraryModel({ _store: store });
+      expect(model.store).toBe(store);
+    });
+
+    it('se construit avec un itinéraire initial', () => {
+      const model = createModel({ name: 'Mon tour' });
+      expect(model.route.name).toBe('Mon tour');
+    });
+
+    it('formatItinerary() ajoute start et end si absents', () => {
+      const model = createModel();
+      const segs = model.route.segments;
+      expect(segs[0].id).toBe('start');
+      expect(segs[segs.length - 1].id).toBe('end');
+    });
+
+    it('formatItinerary() déplace start en première position si mal placé', () => {
+      const model = new ItineraryModel({
+        initial: {
+          id: -1,
+          name: 'X',
+          totalDuration: new TimeSpan(),
+          totalDistance: 0,
+          segments: [
+            makeSegment('mid'),
+            makeSegment('start'),
+            makeSegment('end'),
+          ],
+        },
+      });
+      expect(model.route.segments[0].id).toBe('start');
+    });
+
+    it('formatItinerary() déplace end en dernière position si mal placé', () => {
+      const model = new ItineraryModel({
+        initial: {
+          id: -1,
+          name: 'X',
+          totalDuration: new TimeSpan(),
+          totalDistance: 0,
+          segments: [
+            makeSegment('start'),
+            makeSegment('end'),
+            makeSegment('mid'),
+          ],
+        },
+      });
+      const segs = model.route.segments;
+      expect(segs[segs.length - 1].id).toBe('end');
+    });
+  });
+
+  describe('reset()', () => {
+    it('réinitialise l\'itinéraire avec start et end', () => {
+      const model = createModel({ name: 'Ancien' });
+      model.reset();
+      expect(model.route.name).toBe('Nouveau Convoi');
+      expect(model.route.segments.some(s => s.id === 'start')).toBe(true);
+      expect(model.route.segments.some(s => s.id === 'end')).toBe(true);
+    });
+  });
+
+  describe('renameItinerary()', () => {
+    it('renomme l\'itinéraire', () => {
+      const model = createModel({ name: 'Ancien nom' });
+      model.renameItinerary('Nouveau nom');
+      expect(model.route.name).toBe('Nouveau nom');
+    });
+  });
+
+  describe('setDepartureDateTime()', () => {
+    it('met à jour l\'heure du premier segment', () => {
+      const model = createModel();
+      const newDate = new Date('2024-06-01T10:00:00Z');
+      model.setDepartureDateTime(newDate);
+      expect(model.route.segments[0].content.hour.getTime()).toBe(newDate.getTime());
+    });
+
+    it('ignore une date invalide (NaN)', () => {
+      const model = createModel();
+      const before = model.route.segments[0].content.hour.getTime();
+      model.setDepartureDateTime(new Date('invalid'));
+      expect(model.route.segments[0].content.hour.getTime()).toBe(before);
+    });
+  });
+
+  describe('getSegment()', () => {
+    it('renvoie le segment correspondant à l\'ID', () => {
+      const model = createModel();
+      const found = model.getSegment('start');
+      expect(found).toBeDefined();
+      expect(found?.id).toBe('start');
+    });
+
+    it('renvoie undefined si l\'ID n\'existe pas', () => {
+      const model = createModel();
+      expect(model.getSegment('inexistant')).toBeUndefined();
+    });
+  });
+
+  describe('addSegment()', () => {
+    it('ajoute un segment avant le segment end', () => {
+      const model = createModel();
+      const seg = makeSegment('seg-test');
+      model.addSegment(seg);
+      const segs = model.route.segments;
+      const endIdx = segs.findIndex(s => s.id === 'end');
+      const testIdx = segs.findIndex(s => s.id === 'seg-test');
+      expect(testIdx).toBeGreaterThan(-1);
+      expect(testIdx).toBeLessThan(endIdx);
+    });
+  });
+
+  describe('removeSegment()', () => {
+    it('supprime un segment par son ID', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a'));
+      model.removeSegment('seg-a');
+      expect(model.route.segments.find(s => s.id === 'seg-a')).toBeUndefined();
+    });
+
+    it('ne fait rien si l\'ID n\'existe pas', () => {
+      const model = createModel();
+      const before = model.route.segments.length;
+      model.removeSegment('ghost');
+      expect(model.route.segments.length).toBe(before);
+    });
+  });
+
+  describe('renameSegment()', () => {
+    it('renomme un segment par son ID', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a'));
+      model.renameSegment('seg-a', 'Renommé');
+      const seg = model.route.segments.find(s => s.id === 'seg-a');
+      expect(seg?.content.title).toBe('Renommé');
+    });
+  });
+
+  describe('updateSegmentInfo()', () => {
+    it('met à jour le contenu d\'un segment', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a'));
+      model.updateSegmentInfo('seg-a', {
+        title: 'Updated',
+        hour: new Date(),
+        duration: new TimeSpan(1000),
+        distance: 5,
+      });
+      const seg = model.route.segments.find(s => s.id === 'seg-a');
+      expect(seg?.content.title).toBe('Updated');
+      expect(seg?.content.distance).toBe(5);
+    });
+  });
+
+  describe('reorderSegment()', () => {
+    it('déplace un segment à un nouvel index', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a'));
+      model.addSegment(makeSegment('seg-b'));
+      // [start, seg-a, seg-b, end]
+      const beforeIdx = model.route.segments.findIndex(s => s.id === 'seg-a');
+      model.reorderSegment('seg-b', beforeIdx);
+      // seg-b devrait maintenant être à la position de seg-a
+      expect(model.route.segments[beforeIdx].id).toBe('seg-b');
+    });
+
+    it('ne modifie pas si l\'ID n\'existe pas', () => {
+      const model = createModel();
+      const before = [...model.route.segments.map(s => s.id)];
+      model.reorderSegment('ghost', 0);
+      expect(model.route.segments.map(s => s.id)).toEqual(before);
+    });
+  });
+
+  describe('getStep()', () => {
+    it('renvoie une étape par segmentId et stepId', () => {
+      const step = makeStep('step-1');
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [step]));
+      const found = model.getStep('seg-a', 'step-1');
+      expect(found?.id).toBe('step-1');
+    });
+
+    it('renvoie undefined si segment non trouvé', () => {
+      const model = createModel();
+      expect(model.getStep('ghost', 'step-1')).toBeUndefined();
+    });
+
+    it('renvoie undefined si step non trouvée dans le segment', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1')]));
+      expect(model.getStep('seg-a', 'ghost')).toBeUndefined();
+    });
+  });
+
+  describe('addStep()', () => {
+    it('ajoute une étape dans le segment spécifié', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a'));
+      model.addStep('seg-a', makeStep('new-step'));
+      const seg = model.route.segments.find(s => s.id === 'seg-a');
+      expect(seg?.steps.some(s => s.id === 'new-step')).toBe(true);
+    });
+
+    it('insère l\'étape à l\'index spécifié', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1'), makeStep('s2')]));
+      model.addStep('seg-a', makeStep('inserted'), 1);
+      const seg = model.route.segments.find(s => s.id === 'seg-a');
+      const steps = seg?.steps.filter(s => !s.isDefaultSegStart);
+      expect(steps?.[1].id).toBe('inserted');
+    });
+  });
+
+  describe('removeStep()', () => {
+    it('supprime une étape d\'un segment', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1'), makeStep('s2')]));
+      model.removeStep('seg-a', 's1');
+      const seg = model.route.segments.find(s => s.id === 'seg-a');
+      expect(seg?.steps.find(s => s.id === 's1')).toBeUndefined();
+      expect(seg?.steps.some(s => s.id === 's2')).toBe(true);
+    });
+  });
+
+  describe('renameStep()', () => {
+    it('renomme une étape', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1')]));
+      model.renameStep('seg-a', 's1', 'Nouveau titre');
+      const step = model.getStep('seg-a', 's1');
+      expect(step?.content.title).toBe('Nouveau titre');
+    });
+  });
+
+  describe('setStepLocation()', () => {
+    it('met à jour la localisation d\'une étape', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1')]));
+      model.setStepLocation('seg-a', 's1', { lat: 48.8566, lon: 2.3522 });
+      const step = model.getStep('seg-a', 's1');
+      expect(step?.content.location?.lat).toBe(48.8566);
+      expect(step?.content.location?.lon).toBe(2.3522);
+    });
+  });
+
+  describe('reorderStep()', () => {
+    it('déplace une étape dans le même segment', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1'), makeStep('s2'), makeStep('s3')]));
+      // Récupère index réels (après updateStarts peut-être)
+      const seg = model.route.segments.find(s => s.id === 'seg-a')!;
+      const s3Idx = seg.steps.findIndex(s => s.id === 's3');
+      model.reorderStep('seg-a', s3Idx, 'seg-a', 0);
+      const updated = model.route.segments.find(s => s.id === 'seg-a')!;
+      const nonAuto = updated.steps.filter(s => !s.isDefaultSegStart);
+      expect(nonAuto[0].id).toBe('s3');
+    });
+
+    it('déplace une étape vers un autre segment', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1'), makeStep('s2')]));
+      model.addSegment(makeSegment('seg-b', [makeStep('s3'), makeStep('s4')]));
+      const segA = model.route.segments.find(s => s.id === 'seg-a')!;
+      const s2Idx = segA.steps.findIndex(s => s.id === 's2');
+      model.reorderStep('seg-a', s2Idx, 'seg-b', 0);
+      const updatedB = model.route.segments.find(s => s.id === 'seg-b')!;
+      expect(updatedB.steps.some(s => s.id === 's2')).toBe(true);
+    });
+
+    it('ne fait rien si le segment source n\'existe pas', () => {
+      const model = createModel();
+      const before = model.route.segments.length;
+      model.reorderStep('ghost', 0, 'end', 0);
+      expect(model.route.segments.length).toBe(before);
+    });
+
+    it('ne fait rien si fromStepIndex est hors limites', () => {
+      const model = createModel();
+      model.addSegment(makeSegment('seg-a', [makeStep('s1')]));
+      const before = JSON.stringify(model.route.segments);
+      model.reorderStep('seg-a', 99, 'seg-a', 0);
+      expect(JSON.stringify(model.route.segments)).toBe(before);
+    });
+  });
+
+  describe('route getter', () => {
+    it('renvoie le snapshot courant du store', () => {
+      const model = createModel({ name: 'Test' });
+      expect(model.route).toBe(model.store.getSnapshot());
+    });
+  });
+});

--- a/src/customObject/Itinerary/ItineraryModel.test.ts
+++ b/src/customObject/Itinerary/ItineraryModel.test.ts
@@ -6,14 +6,14 @@ import type { Itinerary, Segment, Step } from './types';
 // Mock ItineraryStore pour casser la dépendance circulaire
 // (ItineraryStore.ts crée une instance d'ItineraryModel au niveau module)
 vi.mock('./ItineraryStore', () => {
-  function createItineraryStore(initial?: any) {
-    let itinerary: any = initial ?? {
+  function createItineraryStore(initial?: Itinerary) {
+    let itinerary: Itinerary = initial ?? ({
       id: -1,
       name: 'Nouveau Convoi',
       totalDuration: { _duration: 0 },
       totalDistance: 0,
       segments: [],
-    };
+    } as unknown as Itinerary);
     const listeners = new Set<() => void>();
     return {
       getSnapshot: () => itinerary,
@@ -21,7 +21,7 @@ vi.mock('./ItineraryStore', () => {
         listeners.add(l);
         return () => listeners.delete(l);
       },
-      set(updater: (prev: any) => any) {
+      set(updater: (prev: Itinerary) => Itinerary) {
         itinerary = updater(itinerary);
         listeners.forEach(l => l());
       },

--- a/src/customObject/Itinerary/ItineraryModel.test.ts
+++ b/src/customObject/Itinerary/ItineraryModel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import ItineraryModel from './ItineraryModel';
 import { TimeSpan } from '../TimeSpan';
 import type { Itinerary, Segment, Step } from './types';

--- a/src/customObject/Itinerary/ItineraryNetModel.ts
+++ b/src/customObject/Itinerary/ItineraryNetModel.ts
@@ -32,6 +32,7 @@ export class ItineraryNetModel {
     // Attributs
     public readonly store: ItineraryStore;
     public timeoutID: number = -1;
+    private isDragging: boolean = false;
 
     // Constructeur
     constructor(store: ItineraryStore, post: boolean = false) {
@@ -120,8 +121,10 @@ export class ItineraryNetModel {
      * Permet de lancer un put 2s après la dernière modification
      *
      * Evite trop de sauvegarde, et des problèmes lors d'une réorganisation
+     * Ne fait rien pendant un drag (voir startDrag/endDrag)
      */
     public setupSave(): void {
+        if (this.isDragging) return;
         if (this.timeoutID != -1) {
             clearTimeout(this.timeoutID);
             this.timeoutID = -1;
@@ -130,6 +133,27 @@ export class ItineraryNetModel {
                                             this.timeoutID = -1;
                                             this.put().then();
                                             }, 2000);
+    }
+
+    /**
+     * Signale le début d'un drag : bloque les appels setupSave intermédiaires
+     * et annule tout timeout en cours
+     */
+    public startDrag(): void {
+        if (this.timeoutID != -1) {
+            clearTimeout(this.timeoutID);
+            this.timeoutID = -1;
+        }
+        this.isDragging = true;
+    }
+
+    /**
+     * Signale la fin d'un drag : relance immédiatement un put sans délai
+     */
+    public endDrag(): void {
+        if (!this.isDragging) return;
+        this.isDragging = false;
+        this.put().then();
     }
 
     // Méthodes Privées

--- a/src/customObject/Itinerary/ItineraryStore.test.ts
+++ b/src/customObject/Itinerary/ItineraryStore.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createItineraryStore } from './ItineraryStore';
+import { TimeSpan } from '../TimeSpan';
+import type { Itinerary } from './types';
+
+function makeDefaultItinerary(): Itinerary {
+  return {
+    id: -1,
+    name: 'Test',
+    totalDuration: new TimeSpan(),
+    totalDistance: 0,
+    segments: [],
+  };
+}
+
+describe('createItineraryStore()', () => {
+  it('crée un store avec un itinéraire par défaut si aucun initial', () => {
+    const store = createItineraryStore();
+    const snap = store.getSnapshot();
+    expect(snap.name).toBe('Nouveau Convoi');
+    expect(snap.id).toBe(-1);
+    expect(snap.segments).toEqual([]);
+  });
+
+  it('crée un store avec la valeur initiale fournie', () => {
+    const initial = makeDefaultItinerary();
+    initial.name = 'Mon itinéraire';
+    const store = createItineraryStore(initial);
+    expect(store.getSnapshot().name).toBe('Mon itinéraire');
+  });
+
+  it('getSnapshot() renvoie le snapshot courant', () => {
+    const store = createItineraryStore();
+    const snap = store.getSnapshot();
+    expect(snap).toBeDefined();
+    expect(typeof snap.name).toBe('string');
+  });
+
+  it('set() met à jour l\'itinéraire et notifie les listeners', () => {
+    const store = createItineraryStore(makeDefaultItinerary());
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.set(prev => ({ ...prev, name: 'Nouveau nom' }));
+
+    expect(store.getSnapshot().name).toBe('Nouveau nom');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe() enregistre un listener et renvoie une fonction de désabonnement', () => {
+    const store = createItineraryStore(makeDefaultItinerary());
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.set(prev => prev);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    store.set(prev => prev);
+    expect(listener).toHaveBeenCalledTimes(1); // pas de nouvel appel
+  });
+
+  it('plusieurs listeners sont tous notifiés', () => {
+    const store = createItineraryStore(makeDefaultItinerary());
+    const l1 = vi.fn();
+    const l2 = vi.fn();
+    store.subscribe(l1);
+    store.subscribe(l2);
+
+    store.set(prev => prev);
+
+    expect(l1).toHaveBeenCalledOnce();
+    expect(l2).toHaveBeenCalledOnce();
+  });
+
+  it('après désabonnement d\'un listener, les autres sont encore notifiés', () => {
+    const store = createItineraryStore(makeDefaultItinerary());
+    const l1 = vi.fn();
+    const l2 = vi.fn();
+    const unsub1 = store.subscribe(l1);
+    store.subscribe(l2);
+
+    unsub1();
+    store.set(prev => prev);
+
+    expect(l1).not.toHaveBeenCalled();
+    expect(l2).toHaveBeenCalledOnce();
+  });
+
+  it('set() reçoit l\'état précédent en paramètre', () => {
+    const store = createItineraryStore(makeDefaultItinerary());
+    store.set(prev => {
+      expect(prev.name).toBe('Test');
+      return { ...prev, name: 'Updated' };
+    });
+    expect(store.getSnapshot().name).toBe('Updated');
+  });
+});

--- a/src/customObject/Itinerary/utils.test.ts
+++ b/src/customObject/Itinerary/utils.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { updateStarts } from './utils';
+import { TimeSpan } from '../TimeSpan';
+import type { Segment, Step } from './types';
+
+// Helpers de construction
+function makeStep(id: string, overrides: Partial<Step> = {}): Step {
+  return {
+    id,
+    content: { title: id, duration: new TimeSpan() },
+    isDefaultSegStart: false,
+    ...overrides,
+  };
+}
+
+function makeSegment(id: string, durationMs = 0, steps: Step[] = [], overrides: Partial<Segment> = {}): Segment {
+  return {
+    id,
+    content: {
+      title: id,
+      hour: new Date(0),
+      duration: new TimeSpan(durationMs),
+      distance: 0,
+    },
+    isStartEnd: false,
+    steps,
+    ...overrides,
+  };
+}
+
+describe('updateStarts()', () => {
+  const FIXED_DATE = new Date('2024-01-01T08:00:00.000Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renvoie un tableau vide si segments est vide', () => {
+    expect(updateStarts([])).toEqual([]);
+  });
+
+  it('supprime les étapes isDefaultSegStart existantes', () => {
+    const step = makeStep('s1', { isDefaultSegStart: true });
+    const seg = makeSegment('seg1', 0, [step]);
+    // updateStarts nécessite au moins 2 segments pour fonctionner sans crash
+    const seg2 = makeSegment('seg2', 0, []);
+    const result = updateStarts([seg, seg2]);
+    expect(result[0].steps.filter(s => s.isDefaultSegStart)).toHaveLength(0);
+  });
+
+  it('ne propage pas de départ automatique si seulement 2 segments (start+end)', () => {
+    const start = makeSegment('start', 0, [], { isStartEnd: true });
+    const end = makeSegment('end', 0, [], { isStartEnd: true });
+    const result = updateStarts([start, end]);
+    expect(result[0].steps).toHaveLength(0);
+    expect(result[1].steps).toHaveLength(0);
+  });
+
+  it('calcule l\'heure du segment suivant en ajoutant la durée du précédent', () => {
+    const ONE_HOUR = 3_600_000;
+    const start = makeSegment('start', ONE_HOUR, []);
+    start.content.hour = new Date('2024-01-01T08:00:00.000Z');
+    const mid = makeSegment('mid', ONE_HOUR, [makeStep('s1'), makeStep('s2')]);
+    const end = makeSegment('end', 0, []);
+
+    const result = updateStarts([start, mid, end]);
+
+    // seg mid doit commencer 1h après start
+    expect(result[1].content.hour.getTime()).toBe(
+      new Date('2024-01-01T09:00:00.000Z').getTime()
+    );
+    // seg end doit commencer 1h après mid
+    expect(result[2].content.hour.getTime()).toBe(
+      new Date('2024-01-01T10:00:00.000Z').getTime()
+    );
+  });
+
+  it('ajoute une étape isDefaultSegStart au segment start quand le premier segment intermédiaire a des steps', () => {
+    const start = makeSegment('start', 0, []);
+    const mid = makeSegment('mid', 0, [makeStep('step-a'), makeStep('step-b')]);
+    const end = makeSegment('end', 0, []);
+
+    const result = updateStarts([start, mid, end]);
+
+    const defaultStart = result[0].steps.find(s => s.isDefaultSegStart);
+    expect(defaultStart).toBeDefined();
+    expect(defaultStart?.id).toBe('start-start');
+  });
+
+  it('propage les départs automatiques entre les segments intermédiaires', () => {
+    const start = makeSegment('start', 0, []);
+    const mid1 = makeSegment('mid1', 0, [makeStep('a'), makeStep('b')]);
+    const mid2 = makeSegment('mid2', 0, [makeStep('c'), makeStep('d')]);
+    const end = makeSegment('end', 0, []);
+
+    const result = updateStarts([start, mid1, mid2, end]);
+
+    // mid2 doit avoir un step automatique qui correspond à la dernière étape de mid1
+    const autoStart = result[2].steps.find(s => s.isDefaultSegStart);
+    expect(autoStart).toBeDefined();
+    expect(autoStart?.id).toBe('start-mid2');
+  });
+
+  it('normalise une heure invalide (NaN) vers la date système courante', () => {
+    const seg = makeSegment('seg1', 0, []);
+    seg.content.hour = new Date('invalid');
+    // 2 segments minimum pour éviter le crash sur out[FIRST_SEG_INDEX]
+    const seg2 = makeSegment('seg2', 0, []);
+    const result = updateStarts([seg, seg2]);
+    expect(result[0].content.hour.getTime()).toBe(FIXED_DATE.getTime());
+  });
+
+  it('conserve les steps non-default existants', () => {
+    const realStep = makeStep('real');
+    const seg = makeSegment('seg1', 0, [realStep]);
+    const seg2 = makeSegment('seg2', 0, []);
+    const result = updateStarts([seg, seg2]);
+    expect(result[0].steps.some(s => s.id === 'real')).toBe(true);
+  });
+});

--- a/src/customObject/Search/SearchIntentStore.test.ts
+++ b/src/customObject/Search/SearchIntentStore.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  subscribeSearchIntent,
+  getSearchIntentSnapshot,
+  requestSearchForStep,
+  clearSearchIntent,
+} from './SearchIntentStore';
+import type { SearchTarget } from './SearchIntentStore';
+
+// Le store est un singleton avec état global ; on remet à zéro entre les tests
+beforeEach(() => {
+  clearSearchIntent();
+});
+
+describe('SearchIntentStore', () => {
+  describe('getSearchIntentSnapshot()', () => {
+    it('renvoie target null par défaut', () => {
+      const snap = getSearchIntentSnapshot();
+      expect(snap.target).toBeNull();
+    });
+  });
+
+  describe('requestSearchForStep()', () => {
+    it('met à jour target avec les infos de l\'étape', () => {
+      const target: SearchTarget = { segmentId: 'seg-1', stepId: 'step-1' };
+      requestSearchForStep(target);
+      const snap = getSearchIntentSnapshot();
+      expect(snap.target).toEqual(target);
+    });
+
+    it('met à jour focusRequestId à chaque appel', () => {
+      const target: SearchTarget = { segmentId: 'seg-1', stepId: 'step-1' };
+      requestSearchForStep(target);
+      const id1 = getSearchIntentSnapshot().focusRequestId;
+      requestSearchForStep(target);
+      const id2 = getSearchIntentSnapshot().focusRequestId;
+      expect(id2).toBeGreaterThanOrEqual(id1);
+    });
+
+    it('notifie les listeners', () => {
+      const listener = vi.fn();
+      subscribeSearchIntent(listener);
+      requestSearchForStep({ segmentId: 's', stepId: 'step' });
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('clearSearchIntent()', () => {
+    it('remet target à null', () => {
+      requestSearchForStep({ segmentId: 's', stepId: 'step' });
+      clearSearchIntent();
+      expect(getSearchIntentSnapshot().target).toBeNull();
+    });
+
+    it('conserve le focusRequestId lors du clear', () => {
+      requestSearchForStep({ segmentId: 's', stepId: 'step' });
+      const idBefore = getSearchIntentSnapshot().focusRequestId;
+      clearSearchIntent();
+      expect(getSearchIntentSnapshot().focusRequestId).toBe(idBefore);
+    });
+
+    it('notifie les listeners', () => {
+      const listener = vi.fn();
+      subscribeSearchIntent(listener);
+      clearSearchIntent();
+      expect(listener).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('subscribeSearchIntent()', () => {
+    it('enregistre un listener et retourne une fonction de désabonnement', () => {
+      const listener = vi.fn();
+      const unsub = subscribeSearchIntent(listener);
+      requestSearchForStep({ segmentId: 's', stepId: 'step' });
+      expect(listener).toHaveBeenCalledOnce();
+      unsub();
+      requestSearchForStep({ segmentId: 's', stepId: 'step' });
+      expect(listener).toHaveBeenCalledOnce(); // pas de second appel
+    });
+
+    it('plusieurs listeners sont tous notifiés', () => {
+      const l1 = vi.fn();
+      const l2 = vi.fn();
+      subscribeSearchIntent(l1);
+      subscribeSearchIntent(l2);
+      requestSearchForStep({ segmentId: 's', stepId: 'step' });
+      expect(l1).toHaveBeenCalledOnce();
+      expect(l2).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/customObject/TimeSpan.test.ts
+++ b/src/customObject/TimeSpan.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { TimeSpan, TimespanOffset } from './TimeSpan';
+
+describe('TimeSpan', () => {
+  describe('constructor', () => {
+    it('crée un TimeSpan à 0 par défaut', () => {
+      const ts = new TimeSpan();
+      expect(ts.duration).toBe(0);
+    });
+
+    it('crée un TimeSpan avec une durée donnée', () => {
+      const ts = new TimeSpan(5000);
+      expect(ts.duration).toBe(5000);
+    });
+  });
+
+  describe('set()', () => {
+    it('met à jour la durée', () => {
+      const ts = new TimeSpan(1000);
+      ts.set(9000);
+      expect(ts.duration).toBe(9000);
+    });
+
+    it('met à jour le timespan décomposé', () => {
+      const ts = new TimeSpan();
+      ts.set(3_661_000); // 1h 1min 1s
+      const composed = ts.getTimeSpanComposed();
+      expect(composed.hours).toBe(1);
+      expect(composed.minutes).toBe(1);
+      expect(composed.seconds).toBe(1);
+    });
+  });
+
+  describe('calculTimespan()', () => {
+    it('calcule la différence entre deux dates', () => {
+      const ts = new TimeSpan();
+      const dateA = new Date(2024, 0, 1, 2, 0, 0);
+      const dateB = new Date(2024, 0, 1, 1, 0, 0);
+      ts.calculTimespan(dateA, dateB);
+      expect(ts.duration).toBe(3_600_000); // 1 heure
+    });
+
+    it('peut produire une durée négative si dateA < dateB', () => {
+      const ts = new TimeSpan();
+      const dateA = new Date(2024, 0, 1, 0, 0, 0);
+      const dateB = new Date(2024, 0, 1, 1, 0, 0);
+      ts.calculTimespan(dateA, dateB);
+      expect(ts.duration).toBe(-3_600_000);
+    });
+  });
+
+  describe('msToComposed()', () => {
+    it('décompose 0 ms correctement', () => {
+      const c = TimeSpan.msToComposed(0);
+      expect(c).toEqual({ days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: 0 });
+    });
+
+    it('décompose 1 jour (86 400 000 ms)', () => {
+      const c = TimeSpan.msToComposed(86_400_000);
+      expect(c.days).toBe(1);
+      expect(c.hours).toBe(0);
+      expect(c.minutes).toBe(0);
+    });
+
+    it('décompose 1 heure (3 600 000 ms)', () => {
+      const c = TimeSpan.msToComposed(3_600_000);
+      expect(c.days).toBe(0);
+      expect(c.hours).toBe(1);
+      expect(c.minutes).toBe(0);
+    });
+
+    it('décompose 1 minute (60 000 ms)', () => {
+      const c = TimeSpan.msToComposed(60_000);
+      expect(c.minutes).toBe(1);
+      expect(c.seconds).toBe(0);
+    });
+
+    it('décompose 1 seconde (1 000 ms)', () => {
+      const c = TimeSpan.msToComposed(1_000);
+      expect(c.seconds).toBe(1);
+      expect(c.milliseconds).toBe(0);
+    });
+
+    it('décompose 500 ms', () => {
+      const c = TimeSpan.msToComposed(500);
+      expect(c.milliseconds).toBe(500);
+    });
+
+    it('décompose une valeur complexe (1j 2h 3m 4s 5ms)', () => {
+      const ms = 86_400_000 + 2 * 3_600_000 + 3 * 60_000 + 4 * 1_000 + 5;
+      const c = TimeSpan.msToComposed(ms);
+      expect(c.days).toBe(1);
+      expect(c.hours).toBe(2);
+      expect(c.minutes).toBe(3);
+      expect(c.seconds).toBe(4);
+      expect(c.milliseconds).toBe(5);
+    });
+  });
+
+  describe('getTimeSpanComposed()', () => {
+    it('renvoie la décomposition correcte après construction', () => {
+      const ts = new TimeSpan(3_661_500); // 1h 1m 1s 500ms
+      const c = ts.getTimeSpanComposed();
+      expect(c.hours).toBe(1);
+      expect(c.minutes).toBe(1);
+      expect(c.seconds).toBe(1);
+      expect(c.milliseconds).toBe(500);
+    });
+  });
+
+  describe('toFStr()', () => {
+    it('affiche les minutes par défaut', () => {
+      const ts = new TimeSpan(90 * 60_000); // 1h30
+      const str = ts.toFStr();
+      expect(str).toContain('1');
+      expect(str).toContain('30');
+    });
+
+    it('affiche uniquement les heures avec précision HOURS', () => {
+      const ts = new TimeSpan(3_600_000); // 1h
+      const str = ts.toFStr(TimespanOffset.HOURS);
+      expect(str).toBe('1:');
+    });
+
+    it('affiche heures/minutes/secondes avec précision SECONDS', () => {
+      const ts = new TimeSpan(5_000); // 5s
+      const str = ts.toFStr(TimespanOffset.SECONDS);
+      // toFStr inclut tous les composants >= start jusqu'à la précision (avec les zéros)
+      expect(str).toBe('0:0:5:');
+    });
+
+    it('utilise les unités personnalisées', () => {
+      const ts = new TimeSpan(3_600_000 + 30 * 60_000); // 1h30
+      const str = ts.toFStr(TimespanOffset.MINUTES, {
+        days: 'j ', hours: 'h ', minutes: 'm ', seconds: 's ', milliseconds: 'ms '
+      });
+      expect(str).toBe('1h 30m ');
+    });
+
+    it('affiche les jours si durée >= 1 jour', () => {
+      const ts = new TimeSpan(2 * 86_400_000); // 2j
+      const str = ts.toFStr(TimespanOffset.MINUTES);
+      expect(str).toContain('2');
+    });
+
+    it('affiche heures/minutes/secondes/ms avec précision MS', () => {
+      const ts = new TimeSpan(250);
+      const str = ts.toFStr(TimespanOffset.MS);
+      // Tous les composants jusqu'à MS sont inclus (avec les zéros)
+      expect(str).toBe('0:0:0:250 ');
+    });
+  });
+
+  describe('add()', () => {
+    it('additionne deux durées', () => {
+      const a = new TimeSpan(1000);
+      const b = new TimeSpan(2000);
+      a.add(b);
+      expect(a.duration).toBe(3000);
+    });
+
+    it('renvoie this pour le chaînage', () => {
+      const ts = new TimeSpan(500);
+      const result = ts.add(new TimeSpan(500));
+      expect(result).toBe(ts);
+    });
+  });
+
+  describe('sub()', () => {
+    it('soustrait deux durées', () => {
+      const a = new TimeSpan(5000);
+      const b = new TimeSpan(2000);
+      a.sub(b);
+      expect(a.duration).toBe(3000);
+    });
+
+    it('renvoie this pour le chaînage', () => {
+      const ts = new TimeSpan(1000);
+      const result = ts.sub(new TimeSpan(500));
+      expect(result).toBe(ts);
+    });
+
+    it('peut produire une durée négative', () => {
+      const a = new TimeSpan(100);
+      const b = new TimeSpan(500);
+      a.sub(b);
+      expect(a.duration).toBe(-400);
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,15 @@ export default defineConfig({
       },
     }),
   ],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/main.tsx', 'src/test/**', 'src/**/*.d.ts'],
+    },
+  },
 })


### PR DESCRIPTION
Add startDrag/endDrag methods to ItineraryNetModel that block setupSave calls during drag-and-drop and trigger an immediate put() on drop instead of waiting for the 2s debounce. Wire these into UseDragNDrop handlers so every intermediate reorder during a drag is skipped, with a single calculation fired as soon as the user releases.