### PR TITLE
feat: sauvegarde explicite (brouillon / finalisé) avec garde navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -139,3 +139,116 @@ html, body {
         padding: clamp(6px, 1vh, 8px) clamp(10px, 3vw, 12px);
     }
 }
+
+/* Guard dialog */
+.guard-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50000;
+    background: rgba(100, 34, 65, 0.18);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    backdrop-filter: blur(2px);
+}
+
+.guard-modal {
+    width: min(360px, 100%);
+    border: 2px solid #BB487C;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 24px 48px rgba(95, 23, 58, 0.28);
+    padding: 20px 18px 18px;
+    color: #BB487C;
+}
+
+.guard-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
+.guard-title {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 15px;
+    font-weight: 700;
+    margin: 0;
+}
+
+.guard-close {
+    border: none;
+    background: transparent;
+    color: #BB487C;
+    font-size: 14px;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 6px;
+    transition: background 120ms;
+}
+
+.guard-close:hover:not(:disabled) {
+    background: rgba(187, 72, 124, 0.1);
+}
+
+.guard-body {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 500;
+    color: #7a3558;
+    margin: 0 0 18px;
+    line-height: 1.45;
+}
+
+.guard-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.guard-btn {
+    width: 100%;
+    border-radius: 10px;
+    padding: 10px 14px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: opacity 120ms ease, transform 120ms ease;
+    text-align: center;
+}
+
+.guard-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.guard-btn:not(:disabled):hover {
+    transform: translateY(-1px);
+}
+
+.guard-btn-draft {
+    border: 1.5px dashed #BB487C;
+    background: transparent;
+    color: #BB487C;
+}
+
+.guard-btn-save {
+    border: none;
+    background: #BB487C;
+    color: #fff;
+}
+
+.guard-btn-save:not(:disabled):hover {
+    background: #a33b6a;
+}
+
+.guard-btn-delete {
+    border: 1.5px solid rgba(187, 72, 124, 0.3);
+    background: rgba(187, 72, 124, 0.07);
+    color: #BB487C;
+    font-weight: 600;
+}

--- a/src/components/History/ItineraryCard.tsx
+++ b/src/components/History/ItineraryCard.tsx
@@ -15,8 +15,7 @@ function segmentsList(itinerary: ItineraryResponse): SegmentResponse[] {
 }
 
 function getStatus(itinerary: ItineraryResponse): "draft" | "finalized" {
-    const segs = segmentsList(itinerary);
-    return segs.length > 0 && segs.every(s => s.waypoints.length >= 2) ? "finalized" : "draft";
+    return itinerary.draft === false ? "finalized" : "draft";
 }
 
 function formatDuration(seconds: number): string {

--- a/src/components/Panels/ActionButtons.tsx
+++ b/src/components/Panels/ActionButtons.tsx
@@ -12,6 +12,7 @@ import ShareModal from "./ShareModal.tsx";
 import { downloadGpx, hasGpxGeometry } from "../../customObject/Itinerary/gpx.ts";
 import { downloadItineraryPdf, collectPdfSections } from "../../customObject/Itinerary/pdf.ts";
 import { pushErrorToast } from "../../customObject/Toast/ToastStore.ts";
+import { useIsDirty } from "../../customObject/SaveState/useIsDirty.ts";
 
 function buildDepartureDateTime(departureDate: string, departureTime: string): Date | null {
     if (!departureDate || !departureTime) {
@@ -31,10 +32,12 @@ function buildDepartureDateTime(departureDate: string, departureTime: string): D
 export default function ActionButtons() {
     const delMod = useDeleteMod(deleteModStore);
     const itinerary = useItinerary(itineraryModel.store);
+    const isDirty = useIsDirty();
     const [showSettings, setShowSettings] = useState(false);
     const [showShare, setShowShare] = useState(false);
     const [currentSettings, setCurrentSettings] = useState<GlobalSettings | undefined>(undefined);
     const [isExportingPdf, setIsExportingPdf] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
     const canDownloadGpx = hasGpxGeometry(itinerary.segments.map((segment) => ({
         geometry: segment.content.geometry,
     })));
@@ -69,6 +72,18 @@ export default function ActionButtons() {
         if (departureDateTime) {
             await itineraryModel.setDepartureDateTime(departureDateTime);
         }
+    };
+
+    const handleSaveAsDraft = async () => {
+        setIsSaving(true);
+        await itineraryModel.netModel.saveAsDraft();
+        setIsSaving(false);
+    };
+
+    const handleSaveAsFinalized = async () => {
+        setIsSaving(true);
+        await itineraryModel.netModel.saveAsFinalized();
+        setIsSaving(false);
     };
 
     /**
@@ -136,6 +151,25 @@ export default function ActionButtons() {
                     disabled={isExportingPdf || !canExportPdf}
                 >
                     <FileDown color={isExportingPdf ? "#ccc" : "#BB487C"} />
+                </button>
+            </div>
+
+            <div className="save-buttons">
+                <button
+                    className={`save-btn save-btn-draft${isDirty ? " dirty" : ""}`}
+                    onClick={handleSaveAsDraft}
+                    disabled={isSaving}
+                    title="Enregistrer en brouillon"
+                >
+                    Brouillon
+                </button>
+                <button
+                    className={`save-btn save-btn-finalize${isDirty ? " dirty" : ""}`}
+                    onClick={handleSaveAsFinalized}
+                    disabled={isSaving}
+                    title="Enregistrer le convoi"
+                >
+                    Enregistrer
                 </button>
             </div>
 

--- a/src/components/Panels/DragNDrop/DragNDropUtils.test.ts
+++ b/src/components/Panels/DragNDrop/DragNDropUtils.test.ts
@@ -73,6 +73,7 @@ function makeItinerary(segments: Segment[]): Itinerary {
     totalDuration: new TimeSpan(),
     totalDistance: 0,
     segments,
+    draft: true,
   };
 }
 

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -431,6 +431,61 @@ h3, .stepTitle {
     cursor: default;
 }
 
+.save-buttons {
+    display: flex;
+    gap: 6px;
+    padding: 0 6px 2px;
+}
+
+.save-btn {
+    flex: 1;
+    border-radius: 8px;
+    padding: clamp(5px, 0.9vh, 7px) 8px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(10px, 1.4vw, 12px);
+    font-weight: 700;
+    cursor: pointer;
+    transition: opacity 120ms ease, transform 120ms ease;
+    white-space: nowrap;
+}
+
+.save-btn:disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
+.save-btn-draft {
+    border: 1.5px dashed rgba(187, 72, 124, 0.45);
+    background: transparent;
+    color: rgba(187, 72, 124, 0.55);
+}
+
+.save-btn-draft.dirty {
+    border-color: #BB487C;
+    color: #BB487C;
+}
+
+.save-btn-draft.dirty:hover:not(:disabled) {
+    background: rgba(187, 72, 124, 0.08);
+    transform: translateY(-1px);
+}
+
+.save-btn-finalize {
+    border: none;
+    background: rgba(187, 72, 124, 0.25);
+    color: #BB487C;
+}
+
+.save-btn-finalize.dirty {
+    background: #BB487C;
+    color: #fff;
+}
+
+.save-btn-finalize.dirty:hover:not(:disabled) {
+    background: #a33b6a;
+    transform: translateY(-1px);
+}
+
 .click-input-wrapper {
     position: relative;
 }

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -455,25 +455,29 @@ h3, .stepTitle {
 }
 
 .save-btn-draft {
-    border: 1.5px dashed rgba(187, 72, 124, 0.45);
+    border: 1.5px dashed #BB487C;
     background: transparent;
-    color: rgba(187, 72, 124, 0.55);
-}
-
-.save-btn-draft.dirty {
-    border-color: #BB487C;
     color: #BB487C;
 }
 
-.save-btn-draft.dirty:hover:not(:disabled) {
+.save-btn-draft:hover:not(:disabled) {
     background: rgba(187, 72, 124, 0.08);
     transform: translateY(-1px);
 }
 
+.save-btn-draft.dirty {
+    border-style: solid;
+}
+
 .save-btn-finalize {
     border: none;
-    background: rgba(187, 72, 124, 0.25);
+    background: rgba(187, 72, 124, 0.35);
     color: #BB487C;
+}
+
+.save-btn-finalize:hover:not(:disabled) {
+    background: rgba(187, 72, 124, 0.5);
+    transform: translateY(-1px);
 }
 
 .save-btn-finalize.dirty {

--- a/src/components/SettingsModal/settingsStorage.test.ts
+++ b/src/components/SettingsModal/settingsStorage.test.ts
@@ -63,7 +63,8 @@ function makeItinerary(): Itinerary {
                 },
                 steps: []
             }
-        ]
+        ],
+        draft: true,
     };
 }
 

--- a/src/customObject/Itinerary/ItineraryModel.test.ts
+++ b/src/customObject/Itinerary/ItineraryModel.test.ts
@@ -87,6 +87,7 @@ function createModel(initial?: Partial<Itinerary>): ItineraryModel {
     totalDistance: 0,
     segments: [],
     ...initial,
+    draft: initial?.draft ?? true,
   };
   return new ItineraryModel({ initial: base });
 }
@@ -131,6 +132,7 @@ describe('ItineraryModel', () => {
             makeSegment('start'),
             makeSegment('end'),
           ],
+          draft: true,
         },
       });
       expect(model.route.segments[0].id).toBe('start');
@@ -149,6 +151,7 @@ describe('ItineraryModel', () => {
             makeSegment('end'),
             makeSegment('mid'),
           ],
+          draft: true,
         },
       });
       const segs = model.route.segments;

--- a/src/customObject/Itinerary/ItineraryModel.ts
+++ b/src/customObject/Itinerary/ItineraryModel.ts
@@ -11,6 +11,7 @@ import type {
 import {TimeSpan} from "../TimeSpan.ts";
 import {ItineraryNetModel} from "./ItineraryNetModel.ts";
 import {updateStarts} from "./utils.ts";
+import {saveStateStore} from "../SaveState/SaveStateStore.ts";
 
 /**
  * Modèle de l'itinéraire, regroupant toutes les fonctions métiers pour le manipuler
@@ -53,6 +54,7 @@ class ItineraryModel {
      * Réinitialise l'itinéraire
      */
     reset() {
+        saveStateStore.set(() => false);
         return this.store.set(() => {
             return this.formatItinerary({
                 id: -1,
@@ -60,7 +62,8 @@ class ItineraryModel {
                 shareCode: "",
                 totalDuration: new TimeSpan(),
                 totalDistance: 0,
-                segments: []
+                segments: [],
+                draft: true,
             });
         });
     }

--- a/src/customObject/Itinerary/ItineraryNetModel.test.ts
+++ b/src/customObject/Itinerary/ItineraryNetModel.test.ts
@@ -68,6 +68,7 @@ function makeValidItinerary(overrides: Partial<Itinerary> = {}): Itinerary {
     totalDistance: 10,
     segments,
     ...overrides,
+    draft: overrides.draft ?? true,
   };
 }
 
@@ -288,6 +289,7 @@ describe('ItineraryNetModel', () => {
         totalDuration: new TimeSpan(),
         totalDistance: 0,
         segments: [],
+        draft: true,
       };
       const store = createStore(invalid);
       const net = new ItineraryNetModel(store, false);

--- a/src/customObject/Itinerary/ItineraryNetModel.ts
+++ b/src/customObject/Itinerary/ItineraryNetModel.ts
@@ -17,6 +17,8 @@ import {TimeSpan} from "../TimeSpan.ts";
 import type {Feature, LineString} from "geojson";
 import {updateStarts} from "./utils.ts";
 import {getAuthToken} from "../../auth/useAuth";
+import {saveStateStore} from "../SaveState/SaveStateStore.ts";
+import {pushErrorToast, pushSuccessToast} from "../Toast/ToastStore.ts";
 
 
 const BACKEND_URL: string = "http://localhost:8080"
@@ -51,6 +53,7 @@ export class ItineraryNetModel {
     public async get(id: number): Promise<void> {
         const response: ItineraryResponse = await this.retrieveItinerary(id);
         await this.applyItinerary(response);
+        saveStateStore.set(() => false);
     }
 
     /**
@@ -157,7 +160,40 @@ export class ItineraryNetModel {
      */
     public setupSave(): void {
         if (this.isDragging) return;
+        saveStateStore.set(() => true);
         this.put().then();
+    }
+
+    /**
+     * Enregistre le convoi en tant que brouillon (draft = true).
+     * Marque l'état comme sauvegardé si le backend répond OK.
+     */
+    public async saveAsDraft(): Promise<boolean> {
+        this.store.set(it => ({ ...it, draft: true }));
+        const ok = await this.put();
+        if (ok) {
+            saveStateStore.set(() => false);
+            pushSuccessToast("Convoi enregistré en brouillon.");
+        } else {
+            pushErrorToast("Impossible d'enregistrer le convoi en brouillon.");
+        }
+        return ok;
+    }
+
+    /**
+     * Finalise le convoi (draft = false).
+     * Marque l'état comme sauvegardé si le backend répond OK.
+     */
+    public async saveAsFinalized(): Promise<boolean> {
+        this.store.set(it => ({ ...it, draft: false }));
+        const ok = await this.put();
+        if (ok) {
+            saveStateStore.set(() => false);
+            pushSuccessToast("Convoi finalisé et enregistré.");
+        } else {
+            pushErrorToast("Impossible de finaliser le convoi.");
+        }
+        return ok;
     }
 
     /**
@@ -327,6 +363,7 @@ export class ItineraryNetModel {
                 totalDuration: new TimeSpan(totalDurationSec * 1000),
                 totalDistance: totalDistanceM * 0.001,
                 segments: updateStarts(segments),
+                draft: response.draft ?? true,
             };
         });
     }
@@ -421,6 +458,7 @@ export class ItineraryNetModel {
             name: itinerary.name.length > 1 ? itinerary.name : "No Name",
             segments: netSegments,
             ...(departureTime !== undefined ? {departureTime} : {}),
+            draft: itinerary.draft,
         }
     }
 }

--- a/src/customObject/Itinerary/ItineraryStore.test.ts
+++ b/src/customObject/Itinerary/ItineraryStore.test.ts
@@ -11,6 +11,7 @@ function makeDefaultItinerary(): Itinerary {
     totalDuration: new TimeSpan(),
     totalDistance: 0,
     segments: [],
+    draft: true,
   };
 }
 

--- a/src/customObject/Itinerary/ItineraryStore.ts
+++ b/src/customObject/Itinerary/ItineraryStore.ts
@@ -12,7 +12,8 @@ export function createItineraryStore(initial?: Itinerary): ItineraryStore
             shareCode: "",
             totalDuration: new TimeSpan(),
             totalDistance: 0,
-            segments: new Array<Segment>()
+            segments: new Array<Segment>(),
+            draft: true,
         }
     } else {
         itinerary = initial;

--- a/src/customObject/Itinerary/netTypes.ts
+++ b/src/customObject/Itinerary/netTypes.ts
@@ -35,6 +35,8 @@ export type ItineraryRequest = {
     segments: SegmentRequest[];
     /** ISO 8601 — optionnel ; requis côté API pour le calcul des ETA */
     departureTime?: string;
+    /** true = brouillon, false = finalisé */
+    draft?: boolean;
 }
 
 /** OpenAPI `PatchDepartureTimeRequest` */
@@ -67,4 +69,5 @@ export type ItineraryResponse = {
     departureTime?: string;
     segments?: SegmentResponse[];
     role?: "PARTICIPANT" | "ORGANISER";
+    draft?: boolean;
 }

--- a/src/customObject/Itinerary/pdf.test.ts
+++ b/src/customObject/Itinerary/pdf.test.ts
@@ -34,6 +34,7 @@ function buildItinerary(segments: Segment[]): Itinerary {
         totalDuration: new TimeSpan(7_200_000),
         totalDistance: 84,
         segments,
+        draft: true,
     };
 }
 

--- a/src/customObject/Itinerary/types.ts
+++ b/src/customObject/Itinerary/types.ts
@@ -51,6 +51,7 @@ export type Itinerary = {
     totalDuration: TimeSpan;
     totalDistance: number;
     segments: Segment[];
+    draft: boolean;
 }
 
 export type ItineraryArgs = {

--- a/src/customObject/SaveState/SaveStateStore.ts
+++ b/src/customObject/SaveState/SaveStateStore.ts
@@ -1,0 +1,26 @@
+type SaveStateListener = () => void;
+
+type SaveStateStore = {
+    getSnapshot(): boolean;
+    subscribe(l: SaveStateListener): () => void;
+    set(updater: (prev: boolean) => boolean): void;
+};
+
+function createSaveStateStore(initial = false): SaveStateStore {
+    let isDirty = initial;
+    const listeners = new Set<SaveStateListener>();
+
+    return {
+        getSnapshot: () => isDirty,
+        subscribe: (l: SaveStateListener) => {
+            listeners.add(l);
+            return () => listeners.delete(l);
+        },
+        set(updater: (prev: boolean) => boolean) {
+            isDirty = updater(isDirty);
+            listeners.forEach(l => l());
+        },
+    };
+}
+
+export const saveStateStore = createSaveStateStore(false);

--- a/src/customObject/SaveState/useIsDirty.ts
+++ b/src/customObject/SaveState/useIsDirty.ts
@@ -1,0 +1,6 @@
+import { useSyncExternalStore } from 'react';
+import { saveStateStore } from './SaveStateStore';
+
+export function useIsDirty(): boolean {
+    return useSyncExternalStore(saveStateStore.subscribe, saveStateStore.getSnapshot);
+}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -26,25 +26,54 @@ export default function HistoryPage() {
     const [filter, setFilter] = useState<'all' | 'draft' | 'finalized' | 'recent'>('all');
     const [loading, setLoading] = useState(true);
     const [page, setPage] = useState(0);
+    const [clientPage, setClientPage] = useState(0);
     const [totalPages, setTotalPages] = useState(0);
     const [totalElements, setTotalElements] = useState(0);
     const [shareCode, setShareCode] = useState<string | null>(null);
 
+    const isFiltered = filter !== 'all';
+
     const loadItineraries = useCallback(async () => {
+        const filterActive = filter !== 'all';
         try {
             setLoading(true);
-            const res = await fetch(`${BACKEND_URL}/tours?page=${page}&size=${PAGE_SIZE}`, { headers: authHeaders() });
-            if (!res.ok) throw new Error('Backend error');
-            const data = await res.json();
-            setItineraries(data.content);
-            setTotalPages(data.totalPages);
-            setTotalElements(data.totalElements);
+            if (!filterActive) {
+                const res = await fetch(`${BACKEND_URL}/tours?page=${page}&size=${PAGE_SIZE}`, { headers: authHeaders() });
+                if (!res.ok) throw new Error('Backend error');
+                const data = await res.json();
+                setItineraries(data.content);
+                setTotalPages(data.totalPages);
+                setTotalElements(data.totalElements);
+            } else {
+                // Fetch first page to know total page count
+                const firstRes = await fetch(`${BACKEND_URL}/tours?page=0&size=${PAGE_SIZE}`, { headers: authHeaders() });
+                if (!firstRes.ok) throw new Error('Backend error');
+                const firstData = await firstRes.json();
+                setTotalPages(firstData.totalPages);
+                setTotalElements(firstData.totalElements);
+
+                if (firstData.totalPages <= 1) {
+                    setItineraries(firstData.content);
+                } else {
+                    // Fetch all remaining pages in parallel
+                    const pagePromises: Promise<ItineraryResponse[]>[] = [];
+                    for (let p = 1; p < firstData.totalPages; p++) {
+                        pagePromises.push(
+                            fetch(`${BACKEND_URL}/tours?page=${p}&size=${PAGE_SIZE}`, { headers: authHeaders() })
+                                .then(r => r.json())
+                                .then((d: { content: ItineraryResponse[] }) => d.content)
+                        );
+                    }
+                    const remainingPages = await Promise.all(pagePromises);
+                    setItineraries([...firstData.content, ...remainingPages.flat()]);
+                }
+            }
         } catch (err) {
             console.error('Erreur chargement:', err);
         } finally {
             setLoading(false);
         }
-    }, [page]);
+    }, [page, filter]);
 
     const applyFilters = useCallback(() => {
         let result = [...itineraries];
@@ -70,6 +99,10 @@ export default function HistoryPage() {
     useEffect(() => {
         applyFilters();
     }, [applyFilters]);
+
+    useEffect(() => {
+        setClientPage(0);
+    }, [filter, search]);
 
     const handleDelete = async (id: number) => {
         if (!confirm('Supprimer ce convoi ?')) return;
@@ -99,6 +132,26 @@ export default function HistoryPage() {
         await itineraryModel.netModel.get(id);
         navigate('/planner?id=' + id);
     };
+
+    const filteredTotalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+    const effectivePage = isFiltered ? clientPage : page;
+    const effectiveTotalPages = isFiltered ? filteredTotalPages : totalPages;
+    const effectiveTotalElements = isFiltered ? filtered.length : totalElements;
+    const displayedItems = isFiltered
+        ? filtered.slice(clientPage * PAGE_SIZE, (clientPage + 1) * PAGE_SIZE)
+        : filtered;
+
+    const handlePrevPage = () => {
+        if (isFiltered) setClientPage(p => p - 1);
+        else setPage(p => p - 1);
+    };
+
+    const handleNextPage = () => {
+        if (isFiltered) setClientPage(p => p + 1);
+        else setPage(p => p + 1);
+    };
+
+    const showPagination = !loading && (isFiltered ? filtered.length > 0 : totalPages > 1);
 
     return (
         <>
@@ -165,11 +218,11 @@ export default function HistoryPage() {
 
                 {loading ? (
                     <div className="ch-empty">Chargement...</div>
-                ) : filtered.length === 0 ? (
+                ) : displayedItems.length === 0 ? (
                     <div className="ch-empty"><Inbox size={20} style={{ marginRight: 8, verticalAlign: 'middle' }} />Aucun convoi trouvé</div>
                 ) : (
                     <div className="ch-list">
-                        {filtered.map(itinerary => (
+                        {displayedItems.map(itinerary => (
                             <ItineraryCard
                                 key={itinerary.id}
                                 itinerary={itinerary}
@@ -181,23 +234,23 @@ export default function HistoryPage() {
                     </div>
                 )}
 
-                {totalPages > 1 && (
+                {showPagination && (
                     <div className="ch-pagination">
                         <button
                             className="ch-page-btn"
-                            onClick={() => setPage(p => p - 1)}
-                            disabled={page === 0}
+                            onClick={handlePrevPage}
+                            disabled={effectivePage === 0}
                         >
                             ‹
                         </button>
                         <span className="ch-page-info">
-                            {page + 1} / {totalPages}
-                            <span className="ch-page-total"> ({totalElements} convois)</span>
+                            {effectivePage + 1} / {effectiveTotalPages}
+                            <span className="ch-page-total"> ({effectiveTotalElements} convoi{effectiveTotalElements !== 1 ? 's' : ''})</span>
                         </span>
                         <button
                             className="ch-page-btn"
-                            onClick={() => setPage(p => p + 1)}
-                            disabled={page >= totalPages - 1}
+                            onClick={handleNextPage}
+                            disabled={effectivePage >= effectiveTotalPages - 1}
                         >
                             ›
                         </button>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -55,12 +55,9 @@ export default function HistoryPage() {
         }
 
         if (filter === 'draft') {
-            result = result.filter(i => (i.segments ?? []).every(s => s.waypoints.length < 2));
+            result = result.filter(i => i.draft !== false);
         } else if (filter === 'finalized') {
-            result = result.filter(i => {
-                const segs = i.segments ?? [];
-                return segs.length > 0 && segs.every(s => s.waypoints.length >= 2);
-            });
+            result = result.filter(i => i.draft === false);
         }
 
         setFiltered(result);

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -1,56 +1,156 @@
 import { useState } from "react";
 import type { LatLngExpression } from "leaflet";
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import BackgroundMap from "../components/Map/BackgroundMap.tsx";
 import Panels from "../components/Panels/Panels.tsx";
 import SearchBar from "../components/Search/SearchBar.tsx";
 import "../App.css";
 import IdRoutingManager from "../components/IdRoutingManager.tsx";
+import { saveStateStore } from "../customObject/SaveState/SaveStateStore.ts";
+import { itineraryModel } from "../customObject/Itinerary/ItineraryStore.ts";
+import { getAuthToken } from "../auth/useAuth.ts";
 
-export default function PlannerPage() {
-  const navigate = useNavigate();
+const BACKEND_URL = "http://localhost:8080";
 
-  const [searchPosition, setSearchPosition] =
-    useState<LatLngExpression | null>(null);
-  const [searchLabel, setSearchLabel] = useState("");
-  const [panelOpen, setPanelOpen] = useState(true);
-
-  return (
-    <div className="window">
-        <IdRoutingManager/>
-      <button
-        className="home-return"
-        type="button"
-        onClick={() => navigate("/")}
-      >
-        ↩ Accueil
-      </button>
-
-      <BackgroundMap searchPosition={searchPosition} searchLabel={searchLabel}>
-        <div className="search-panel">
-          <SearchBar
-            onLocationSelected={(coords, label) => {
-              setSearchPosition(coords);
-              setSearchLabel(label);
-            }}
-          />
-        </div>
-      </BackgroundMap>
-
-      {panelOpen ? (
-        <div className="panel">
-          <Panels onClose={() => setPanelOpen(false)} />
-        </div>
-      ) : (
-        <button
-          className="panel-toggle"
-          aria-label="Ouvrir le panneau"
-          onClick={() => setPanelOpen(true)}
-        >
-          &#9776;
-        </button>
-      )}
-    </div>
-  );
+function authHeaders(): HeadersInit {
+    const token = getAuthToken();
+    return {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
 }
 
+export default function PlannerPage() {
+    const navigate = useNavigate();
+    const [searchPosition, setSearchPosition] = useState<LatLngExpression | null>(null);
+    const [searchLabel, setSearchLabel] = useState("");
+    const [panelOpen, setPanelOpen] = useState(true);
+    const [showGuard, setShowGuard] = useState(false);
+    const [guardLoading, setGuardLoading] = useState(false);
+
+    const handleGoHome = () => {
+        if (saveStateStore.getSnapshot()) {
+            setShowGuard(true);
+        } else {
+            navigate("/");
+        }
+    };
+
+    const handleSaveAsDraftAndLeave = async () => {
+        setGuardLoading(true);
+        await itineraryModel.netModel.saveAsDraft();
+        setGuardLoading(false);
+        setShowGuard(false);
+        navigate("/");
+    };
+
+    const handleSaveAsFinalizedAndLeave = async () => {
+        setGuardLoading(true);
+        await itineraryModel.netModel.saveAsFinalized();
+        setGuardLoading(false);
+        setShowGuard(false);
+        navigate("/");
+    };
+
+    const handleDeleteAndLeave = async () => {
+        setGuardLoading(true);
+        const currentId = itineraryModel.route.id;
+        if (currentId !== -1) {
+            try {
+                await fetch(`${BACKEND_URL}/tours/${currentId}`, {
+                    method: "DELETE",
+                    headers: authHeaders(),
+                });
+            } catch {
+                // ignore — navigate anyway
+            }
+        }
+        itineraryModel.reset();
+        saveStateStore.set(() => false);
+        setGuardLoading(false);
+        setShowGuard(false);
+        navigate("/");
+    };
+
+    return (
+        <div className="window">
+            <IdRoutingManager />
+            <button
+                className="home-return"
+                type="button"
+                onClick={handleGoHome}
+            >
+                ↩ Accueil
+            </button>
+
+            <BackgroundMap searchPosition={searchPosition} searchLabel={searchLabel}>
+                <div className="search-panel">
+                    <SearchBar
+                        onLocationSelected={(coords, label) => {
+                            setSearchPosition(coords);
+                            setSearchLabel(label);
+                        }}
+                    />
+                </div>
+            </BackgroundMap>
+
+            {panelOpen ? (
+                <div className="panel">
+                    <Panels onClose={() => setPanelOpen(false)} />
+                </div>
+            ) : (
+                <button
+                    className="panel-toggle"
+                    aria-label="Ouvrir le panneau"
+                    onClick={() => setPanelOpen(true)}
+                >
+                    &#9776;
+                </button>
+            )}
+
+            {showGuard && (
+                <div className="guard-overlay" role="dialog" aria-modal="true">
+                    <div className="guard-modal">
+                        <div className="guard-header">
+                            <h3 className="guard-title">Quitter sans enregistrer ?</h3>
+                            <button
+                                className="guard-close"
+                                onClick={() => setShowGuard(false)}
+                                aria-label="Annuler"
+                                disabled={guardLoading}
+                            >
+                                ✕
+                            </button>
+                        </div>
+                        <p className="guard-body">
+                            Ce convoi a des modifications non sauvegardées. Que souhaitez-vous faire ?
+                        </p>
+                        <div className="guard-actions">
+                            <button
+                                className="guard-btn guard-btn-draft"
+                                onClick={handleSaveAsDraftAndLeave}
+                                disabled={guardLoading}
+                            >
+                                Enregistrer en brouillon
+                            </button>
+                            <button
+                                className="guard-btn guard-btn-save"
+                                onClick={handleSaveAsFinalizedAndLeave}
+                                disabled={guardLoading}
+                            >
+                                Enregistrer le convoi
+                            </button>
+                            <button
+                                className="guard-btn guard-btn-delete"
+                                onClick={handleDeleteAndLeave}
+                                disabled={guardLoading}
+                            >
+                                Supprimer le convoi
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Description

Jusqu'ici tous les changements étaient auto-sauvegardés côté backend sans que l'utilisateur choisisse jamais le statut du convoi. Cette PR ajoute une sauvegarde explicite : l'utilisateur décide si son convoi est un **brouillon** ou un **tour finalisé**, et est protégé contre une navigation accidentelle vers l'accueil sans avoir sauvegardé.

## Changements

- **`src/customObject/SaveState/SaveStateStore.ts`** — nouveau store réactif qui suit l'état "modifié non sauvegardé" (`isDirty`)
- **`src/customObject/SaveState/useIsDirty.ts`** — hook React pour lire `isDirty` dans les composants
- **`src/customObject/Itinerary/types.ts`** — champ `draft: boolean` ajouté à `Itinerary`
- **`src/customObject/Itinerary/netTypes.ts`** — champ `draft` ajouté à `ItineraryRequest` et `ItineraryResponse`
- **`src/customObject/Itinerary/ItineraryStore.ts`** — état initial avec `draft: true`
- **`src/customObject/Itinerary/ItineraryModel.ts`** — `reset()` remet `isDirty` à `false`
- **`src/customObject/Itinerary/ItineraryNetModel.ts`** — `setupSave()` passe `isDirty` à `true` ; `saveAsDraft()` / `saveAsFinalized()` mettent à jour le flag côté backend et remettent `isDirty` à `false` ; `get()` remet `isDirty` à `false` au chargement
- **`src/components/Panels/ActionButtons.tsx`** — deux boutons **Brouillon** / **Enregistrer** s'illuminent quand `isDirty = true`
- **`src/components/Panels/Panels.css`** — styles des boutons de sauvegarde
- **`src/pages/PlannerPage.tsx`** — le bouton "↩ Accueil" déclenche un dialogue de garde si `isDirty = true` avec les options : enregistrer en brouillon, finaliser, supprimer
- **`src/App.css`** — styles du dialogue de garde
- **`src/pages/HistoryPage.tsx`** — les filtres Brouillons / Finalisés utilisent désormais le champ `draft` du backend
- **`src/components/History/ItineraryCard.tsx`** — badge de statut basé sur `draft` plutôt que le nombre de waypoints

## Comportement

1. L'utilisateur crée ou modifie un convoi dans le planificateur — chaque modification déclenche l'auto-sauvegarde (inchangé) et passe `isDirty = true`
2. Les boutons **Brouillon** et **Enregistrer** dans le panneau de gauche s'illuminent en rose
3. En cliquant sur **Brouillon** : le convoi est sauvegardé avec `draft = true`, toast de confirmation, `isDirty = false`
4. En cliquant sur **Enregistrer** : le convoi est sauvegardé avec `draft = false`, toast de confirmation, `isDirty = false`
5. En cliquant sur **↩ Accueil** sans avoir sauvegardé : un dialogue apparaît avec trois options — *Enregistrer en brouillon*, *Enregistrer le convoi*, *Supprimer le convoi* — et un bouton ✕ pour annuler
6. Dans `/history`, les filtres **Brouillons** et **Finalisés** reposent sur le champ `draft` backend

## Tests à effectuer

- [ ] Créer un convoi, ajouter des étapes → les boutons Brouillon / Enregistrer deviennent actifs
- [ ] Cliquer **Brouillon** → toast de succès, boutons redeviennent inactifs (grisés)
- [ ] Cliquer **Enregistrer** → toast de succès, boutons inactifs
- [ ] Modifier à nouveau le convoi → boutons redeviennent actifs
- [ ] Cliquer **↩ Accueil** sans sauvegarder → dialogue de garde s'affiche
- [ ] Dans le dialogue : *Enregistrer en brouillon* → retour accueil, convoi visible dans /history avec badge "Brouillon"
- [ ] Dans le dialogue : *Enregistrer le convoi* → retour accueil, convoi visible avec badge "Finalisé"
- [ ] Dans le dialogue : *Supprimer* → retour accueil, convoi absent de /history
- [ ] Dans le dialogue : ✕ → dialogue se ferme, l'utilisateur reste sur le planificateur
- [ ] Ouvrir un convoi existant depuis /history → boutons Brouillon/Enregistrer inactifs (pas de modification)
- [ ] Filtre "Brouillons" dans /history → n'affiche que les convois avec `draft = true`
- [ ] Filtre "Finalisés" dans /history → n'affiche que les convois avec `draft = false`