### PR TITLE
feat(auth): login par email, paramètres compte, mot de passe oublié

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,6 @@ on:
     branches: [ "dev" ]
 
 jobs:
-  sonarqube:
-    name: SonarQube
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -41,8 +30,33 @@ jobs:
       - name: TypeScript check
         run: ./node_modules/.bin/tsc --noEmit
 
-      - name: Tests unitaires
-        run: npm run test
+      - name: Tests unitaires avec coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report
+          path: coverage/lcov.info
+          retention-days: 1
 
       - name: Build
         run: npm run build
+
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    needs: [build-and-test]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: coverage-report
+          path: coverage
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,8 @@
 sonar.projectKey=Elessiah-sTeam_c15-tour-webapp
 sonar.organization=elessiah-steam
 
-
-# This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=c15-tour-webapp
-#sonar.projectVersion=1.0
-
-
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
-
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.sourceEncoding=UTF-8

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import PlannerPage from "./pages/PlannerPage.tsx";
 import HistoryPage from "./pages/HistoryPage.tsx";
 import LoginPage from "./pages/LoginPage.tsx";
 import RegisterPage from "./pages/RegisterPage.tsx";
+import ForgotPasswordPage from "./pages/ForgotPasswordPage.tsx";
+import ResetPasswordPage from "./pages/ResetPasswordPage.tsx";
 import ToastContainer from "./components/Toast/ToastContainer.tsx";
 import "./App.css";
 
@@ -17,6 +19,8 @@ export default function App() {
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+          <Route path="/reset-password" element={<ResetPasswordPage />} />
           <Route path="/" element={<ProtectedRoute><HomePage /></ProtectedRoute>} />
           <Route path="/planner" element={<ProtectedRoute><PlannerPage /></ProtectedRoute>} />
           <Route path="/history" element={<ProtectedRoute><HistoryPage /></ProtectedRoute>} />

--- a/src/auth/AuthContext.test.tsx
+++ b/src/auth/AuthContext.test.tsx
@@ -6,11 +6,15 @@ import { useAuth } from './useAuth';
 
 // Composant de test pour accéder au contexte
 function TestConsumer() {
-  const { token, login, logout } = useAuth();
+  const { token, email, login, logout, setEmail } = useAuth();
   return (
     <div>
       <span data-testid="token">{token ?? 'null'}</span>
+      <span data-testid="email">{email ?? 'null'}</span>
       <button onClick={() => login('test-token')}>Login</button>
+      <button onClick={() => login('test-token', 'user@example.com')}>Login With Email</button>
+      <button onClick={() => setEmail('updated@example.com')}>Set Email</button>
+      <button onClick={() => setEmail(null)}>Clear Email</button>
       <button onClick={logout}>Logout</button>
     </div>
   );
@@ -44,6 +48,25 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('token').textContent).toBe('stored-token');
   });
 
+  it('initialise email à null si localStorage vide', () => {
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    expect(screen.getByTestId('email').textContent).toBe('null');
+  });
+
+  it('initialise email depuis localStorage', () => {
+    localStorage.setItem('auth_email', 'stored@example.com');
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    expect(screen.getByTestId('email').textContent).toBe('stored@example.com');
+  });
+
   it('login() stocke le token et met à jour l\'état', async () => {
     const user = userEvent.setup();
     render(
@@ -56,9 +79,47 @@ describe('AuthProvider', () => {
     expect(localStorage.getItem('auth_token')).toBe('test-token');
   });
 
-  it('logout() supprime le token et met à jour l\'état', async () => {
+  it('login() avec email stocke l\'email', async () => {
+    const user = userEvent.setup();
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    await user.click(screen.getByText('Login With Email'));
+    expect(screen.getByTestId('email').textContent).toBe('user@example.com');
+    expect(localStorage.getItem('auth_email')).toBe('user@example.com');
+  });
+
+  it('setEmail() met à jour l\'email dans le contexte et localStorage', async () => {
+    const user = userEvent.setup();
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    await user.click(screen.getByText('Set Email'));
+    expect(screen.getByTestId('email').textContent).toBe('updated@example.com');
+    expect(localStorage.getItem('auth_email')).toBe('updated@example.com');
+  });
+
+  it('setEmail(null) supprime l\'email du localStorage', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('auth_email', 'old@example.com');
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+    await user.click(screen.getByText('Clear Email'));
+    expect(screen.getByTestId('email').textContent).toBe('null');
+    expect(localStorage.getItem('auth_email')).toBeNull();
+  });
+
+  it('logout() supprime le token et l\'email', async () => {
     const user = userEvent.setup();
     localStorage.setItem('auth_token', 'existing-token');
+    localStorage.setItem('auth_email', 'user@example.com');
     render(
       <AuthProvider>
         <TestConsumer />
@@ -66,7 +127,9 @@ describe('AuthProvider', () => {
     );
     await user.click(screen.getByText('Logout'));
     expect(screen.getByTestId('token').textContent).toBe('null');
+    expect(screen.getByTestId('email').textContent).toBe('null');
     expect(localStorage.getItem('auth_token')).toBeNull();
+    expect(localStorage.getItem('auth_email')).toBeNull();
   });
 
   it('renvoie les enfants correctement', () => {

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -6,18 +6,37 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         localStorage.getItem("auth_token")
     );
 
-    const login = (newToken: string) => {
+    const [email, setEmail] = useState<string | null>(() =>
+        localStorage.getItem("auth_email")
+    );
+
+    const login = (newToken: string, newEmail?: string) => {
         localStorage.setItem("auth_token", newToken);
         setToken(newToken);
+        if (newEmail) {
+            localStorage.setItem("auth_email", newEmail);
+            setEmail(newEmail);
+        }
     };
 
     const logout = () => {
         localStorage.removeItem("auth_token");
+        localStorage.removeItem("auth_email");
         setToken(null);
+        setEmail(null);
+    };
+
+    const handleSetEmail = (newEmail: string | null) => {
+        if (newEmail) {
+            localStorage.setItem("auth_email", newEmail);
+        } else {
+            localStorage.removeItem("auth_email");
+        }
+        setEmail(newEmail);
     };
 
     return (
-        <AuthContext.Provider value={{ token, login, logout }}>
+        <AuthContext.Provider value={{ token, email, login, logout, setEmail: handleSetEmail }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/auth/authContextDef.ts
+++ b/src/auth/authContextDef.ts
@@ -2,8 +2,10 @@ import { createContext } from "react";
 
 export interface AuthContextType {
     token: string | null;
-    login: (token: string) => void;
+    email: string | null;
+    login: (token: string, email?: string) => void;
     logout: () => void;
+    setEmail: (email: string | null) => void;
 }
 
 export const AuthContext = createContext<AuthContextType | null>(null);

--- a/src/components/AccountSettings/AccountSettingsModal.css
+++ b/src/components/AccountSettings/AccountSettingsModal.css
@@ -1,0 +1,253 @@
+.account-settings-modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 30000;
+    animation: account-settings-fadeIn 0.2s ease;
+}
+
+@keyframes account-settings-fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.account-settings-modal {
+    background: white;
+    border-radius: 16px;
+    width: 100%;
+    max-width: 500px;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    animation: account-settings-slideIn 0.3s ease;
+    overflow: hidden;
+}
+
+@keyframes account-settings-slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.account-settings-modal-header {
+    background: linear-gradient(135deg, #BB487C 0%, #BB487C 100%);
+    color: white;
+    padding: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-shrink: 0;
+    border-radius: 16px 16px 0 0;
+}
+
+.account-settings-modal-header h2 {
+    font-size: 24px;
+    font-weight: 700;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.account-settings-modal-close {
+    background: rgba(255, 255, 255, 0.2);
+    border: none;
+    border-radius: 8px;
+    width: 40px;
+    height: 40px;
+    font-size: 22px;
+    color: white;
+    cursor: pointer;
+    transition: all 0.2s;
+    flex-shrink: 0;
+}
+
+.account-settings-modal-close:hover {
+    background: rgba(255, 255, 255, 0.3);
+    transform: rotate(90deg);
+}
+
+.account-settings-modal-content {
+    padding: 24px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    flex: 1;
+    min-height: 0;
+}
+
+.account-settings-modal-content::-webkit-scrollbar {
+    width: 10px;
+}
+
+.account-settings-modal-content::-webkit-scrollbar-track {
+    background: #f1f1f1;
+}
+
+.account-settings-modal-content::-webkit-scrollbar-thumb {
+    background: #BB487C;
+    border-radius: 5px;
+}
+
+.account-settings-modal-content::-webkit-scrollbar-thumb:hover {
+    background: #BB487C;
+}
+
+.account-settings-section {
+    margin-bottom: 24px;
+}
+
+.account-settings-section-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #2d3748;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.account-settings-form-group {
+    margin-bottom: 16px;
+}
+
+.account-settings-label {
+    display: block;
+    font-size: 14px;
+    font-weight: 500;
+    color: #4a5568;
+    margin-bottom: 6px;
+}
+
+.account-settings-input {
+    width: 100%;
+    padding: 12px 16px;
+    border: 2px solid #e2e8f0;
+    border-radius: 8px;
+    font-size: 15px;
+    font-family: inherit;
+    transition: all 0.2s;
+    box-sizing: border-box;
+}
+
+.account-settings-input:focus {
+    outline: none;
+    border-color: #BB487C;
+    box-shadow: 0 0 0 3px rgba(187, 72, 124, 0.1);
+}
+
+.account-settings-input:read-only {
+    background-color: #f7fafc;
+    color: #718096;
+    cursor: not-allowed;
+}
+
+.account-settings-input:disabled {
+    background-color: #f7fafc;
+    color: #718096;
+    cursor: not-allowed;
+}
+
+.account-settings-message {
+    padding: 12px 16px;
+    border-radius: 8px;
+    font-size: 14px;
+    margin-bottom: 16px;
+    animation: account-settings-slideDown 0.3s ease;
+}
+
+@keyframes account-settings-slideDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.account-settings-message-success {
+    background: #c6f6d5;
+    color: #22543d;
+    border: 1px solid #9ae6b4;
+}
+
+.account-settings-message-error {
+    background: #fed7d7;
+    color: #742a2a;
+    border: 1px solid #fc8181;
+}
+
+.account-settings-modal-footer {
+    padding: 20px 24px;
+    background: #f7fafc;
+    border-top: 1px solid #e2e8f0;
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    flex-shrink: 0;
+    border-radius: 0 0 16px 16px;
+}
+
+.account-settings-btn {
+    padding: 12px 24px;
+    border-radius: 8px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+    border: none;
+    font-family: inherit;
+}
+
+.account-settings-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.account-settings-btn-submit {
+    width: 100%;
+    background: linear-gradient(135deg, #BB487C 0%, #BB487C 100%);
+    color: white;
+    margin-top: 8px;
+}
+
+.account-settings-btn-submit:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(187, 72, 124, 0.3);
+}
+
+.account-settings-btn-logout {
+    background: #fed7d7;
+    color: #742a2a;
+    border: 2px solid #fc8181;
+}
+
+.account-settings-btn-logout:hover {
+    background: #fc8181;
+    color: white;
+    border-color: #fc8181;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(252, 129, 129, 0.3);
+}
+
+@media (max-width: 640px) {
+    .account-settings-modal {
+        max-width: 95vw;
+        max-height: 95vh;
+    }
+
+    .account-settings-modal-header h2 {
+        font-size: 20px;
+    }
+}

--- a/src/components/AccountSettings/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettings/AccountSettingsModal.test.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider } from '../../auth/AuthContext';
+import { AccountSettingsModal } from './AccountSettingsModal';
+
+function renderModal(props: { isOpen?: boolean; onClose?: () => void; onLogout?: () => void } = {}) {
+    const { isOpen = true, onClose = vi.fn(), onLogout = vi.fn() } = props;
+    return render(
+        <AuthProvider>
+            <AccountSettingsModal isOpen={isOpen} onClose={onClose} onLogout={onLogout} />
+        </AuthProvider>
+    );
+}
+
+function renderModalWithEmail(email: string, props: { onClose?: () => void; onLogout?: () => void } = {}) {
+    localStorage.setItem('auth_token', 'test-token');
+    localStorage.setItem('auth_email', email);
+    return renderModal(props);
+}
+
+describe('AccountSettingsModal', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    it('ne rend rien quand isOpen=false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('affiche le modal quand isOpen=true', () => {
+        renderModal();
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('Paramètres du compte')).toBeInTheDocument();
+    });
+
+    it('affiche l\'email de l\'utilisateur connecté', () => {
+        renderModalWithEmail('user@example.com');
+        const emailInput = screen.getByLabelText('Adresse email') as HTMLInputElement;
+        expect(emailInput.value).toBe('user@example.com');
+        expect(emailInput).toHaveAttribute('readonly');
+    });
+
+    it('appelle onClose au clic sur le bouton fermer', async () => {
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        renderModal({ onClose });
+        await user.click(screen.getByRole('button', { name: '✕' }));
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('appelle onClose au clic sur l\'overlay', async () => {
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        renderModal({ onClose });
+        const overlay = document.querySelector('.account-settings-modal-overlay') as HTMLElement;
+        await user.click(overlay);
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('appelle onClose sur la touche Escape', () => {
+        const onClose = vi.fn();
+        renderModal({ onClose });
+        const overlay = document.querySelector('.account-settings-modal-overlay') as HTMLElement;
+        fireEvent.keyDown(overlay, { key: 'Escape' });
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('appelle onLogout au clic sur le bouton se déconnecter', async () => {
+        const onLogout = vi.fn();
+        const user = userEvent.setup();
+        renderModal({ onLogout });
+        await user.click(screen.getByRole('button', { name: /se déconnecter/i }));
+        expect(onLogout).toHaveBeenCalledOnce();
+    });
+
+    it('affiche une erreur si les champs sont vides au submit', async () => {
+        const user = userEvent.setup();
+        renderModal();
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+        expect(screen.getByText('Tous les champs sont requis')).toBeInTheDocument();
+    });
+
+    it('affiche une erreur si les nouveaux mots de passe ne correspondent pas', async () => {
+        const user = userEvent.setup();
+        renderModal();
+        await user.type(screen.getByLabelText('Mot de passe actuel'), 'oldpass');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpass1');
+        await user.type(screen.getByLabelText('Confirmer le nouveau mot de passe'), 'newpass2');
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+        expect(screen.getByText('Les nouveaux mots de passe ne correspondent pas')).toBeInTheDocument();
+    });
+
+    it('affiche une erreur si le nouveau mot de passe est trop court', async () => {
+        const user = userEvent.setup();
+        renderModal();
+        await user.type(screen.getByLabelText('Mot de passe actuel'), 'oldpass');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'short');
+        await user.type(screen.getByLabelText('Confirmer le nouveau mot de passe'), 'short');
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+        expect(screen.getByText(/au moins 8 caractères/i)).toBeInTheDocument();
+    });
+
+    it('affiche un message de succès après changement de mot de passe réussi', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response);
+        renderModalWithEmail('user@example.com');
+
+        await user.type(screen.getByLabelText('Mot de passe actuel'), 'oldpassword');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpassword');
+        await user.type(screen.getByLabelText('Confirmer le nouveau mot de passe'), 'newpassword');
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Mot de passe mis à jour avec succès')).toBeInTheDocument();
+        });
+    });
+
+    it('affiche une erreur si l\'API renvoie une erreur', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: false,
+            json: async () => ({ message: 'Mot de passe actuel incorrect' }),
+        } as Response);
+        renderModalWithEmail('user@example.com');
+
+        await user.type(screen.getByLabelText('Mot de passe actuel'), 'wrongpass');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpassword');
+        await user.type(screen.getByLabelText('Confirmer le nouveau mot de passe'), 'newpassword');
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Mot de passe actuel incorrect')).toBeInTheDocument();
+        });
+    });
+
+    it('affiche une erreur générique si l\'API échoue sans message', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: false,
+            json: async () => ({}),
+        } as Response);
+        renderModal();
+
+        await user.type(screen.getByLabelText('Mot de passe actuel'), 'oldpassword');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpassword');
+        await user.type(screen.getByLabelText('Confirmer le nouveau mot de passe'), 'newpassword');
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Erreur lors de la mise à jour du mot de passe')).toBeInTheDocument();
+        });
+    });
+
+    it('affiche une erreur si le serveur est inaccessible', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+        renderModal();
+
+        await user.type(screen.getByLabelText('Mot de passe actuel'), 'oldpassword');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpassword');
+        await user.type(screen.getByLabelText('Confirmer le nouveau mot de passe'), 'newpassword');
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Erreur de connexion au serveur')).toBeInTheDocument();
+        });
+    });
+
+    it('envoie le token Authorization dans la requête', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response);
+        renderModalWithEmail('user@example.com');
+
+        await user.type(screen.getByLabelText('Mot de passe actuel'), 'oldpassword');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpassword');
+        await user.type(screen.getByLabelText('Confirmer le nouveau mot de passe'), 'newpassword');
+        await user.click(screen.getByRole('button', { name: /mettre à jour/i }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith(
+                'http://localhost:8080/auth/change-password',
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        Authorization: 'Bearer test-token',
+                    }),
+                })
+            );
+        });
+    });
+});

--- a/src/components/AccountSettings/AccountSettingsModal.tsx
+++ b/src/components/AccountSettings/AccountSettingsModal.tsx
@@ -96,7 +96,7 @@ export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSetti
                     text: errorData.message || 'Erreur lors de la mise à jour du mot de passe'
                 });
             }
-        } catch (error) {
+        } catch {
             setMessage({
                 type: 'error',
                 text: 'Erreur de connexion au serveur'

--- a/src/components/AccountSettings/AccountSettingsModal.tsx
+++ b/src/components/AccountSettings/AccountSettingsModal.tsx
@@ -1,0 +1,235 @@
+import { type MouseEvent, useState, useEffect, useContext } from 'react';
+import { createPortal } from 'react-dom';
+import { User, Lock } from 'lucide-react';
+import { AuthContext } from '../../auth/authContextDef';
+import './AccountSettingsModal.css';
+
+interface AccountSettingsModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onLogout: () => void;
+}
+
+export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSettingsModalProps) {
+    const authContext = useContext(AuthContext);
+    const email = authContext?.email || '';
+    const token = authContext?.token || '';
+
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmNewPassword, setConfirmNewPassword] = useState('');
+    const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        if (isOpen) {
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = 'unset';
+        }
+
+        return () => {
+            document.body.style.overflow = 'unset';
+        };
+    }, [isOpen]);
+
+    if (!isOpen) return null;
+
+    const handleOverlayClick = (e: MouseEvent<HTMLDivElement>) => {
+        if (e.target === e.currentTarget) {
+            onClose();
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            onClose();
+        }
+    };
+
+    const handleChangePassword = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setMessage(null);
+
+        // Validate inputs
+        if (!currentPassword || !newPassword || !confirmNewPassword) {
+            setMessage({ type: 'error', text: 'Tous les champs sont requis' });
+            return;
+        }
+
+        if (newPassword !== confirmNewPassword) {
+            setMessage({ type: 'error', text: 'Les nouveaux mots de passe ne correspondent pas' });
+            return;
+        }
+
+        if (newPassword.length < 8) {
+            setMessage({ type: 'error', text: 'Le nouveau mot de passe doit contenir au moins 8 caractères' });
+            return;
+        }
+
+        setLoading(true);
+        try {
+            const response = await fetch('http://localhost:8080/auth/change-password', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+                body: JSON.stringify({
+                    currentPassword,
+                    newPassword
+                })
+            });
+
+            if (response.ok) {
+                setMessage({ type: 'success', text: 'Mot de passe mis à jour avec succès' });
+                setCurrentPassword('');
+                setNewPassword('');
+                setConfirmNewPassword('');
+                setTimeout(() => {
+                    setMessage(null);
+                }, 3000);
+            } else {
+                const errorData = await response.json().catch(() => ({}));
+                setMessage({
+                    type: 'error',
+                    text: errorData.message || 'Erreur lors de la mise à jour du mot de passe'
+                });
+            }
+        } catch (error) {
+            setMessage({
+                type: 'error',
+                text: 'Erreur de connexion au serveur'
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return createPortal(
+        <div
+            className="account-settings-modal-overlay"
+            role="button"
+            aria-label="Fermer"
+            tabIndex={0}
+            onClick={handleOverlayClick}
+            onKeyDown={handleKeyDown}
+        >
+            <div className="account-settings-modal" role="dialog" aria-modal="true">
+                {/* Header */}
+                <div className="account-settings-modal-header">
+                    <h2>
+                        <User size={18} />
+                        Paramètres du compte
+                    </h2>
+                    <button className="account-settings-modal-close" onClick={onClose}>
+                        ✕
+                    </button>
+                </div>
+
+                {/* Content */}
+                <div className="account-settings-modal-content">
+                    {/* Section Informations */}
+                    <div className="account-settings-section">
+                        <div className="account-settings-section-title">
+                            Informations
+                        </div>
+
+                        <div className="account-settings-form-group">
+                            <label className="account-settings-label" htmlFor="account-settings-email">
+                                Adresse email
+                            </label>
+                            <input
+                                id="account-settings-email"
+                                type="email"
+                                className="account-settings-input"
+                                value={email}
+                                readOnly
+                            />
+                        </div>
+                    </div>
+
+                    {/* Section Change Password */}
+                    <div className="account-settings-section">
+                        <div className="account-settings-section-title">
+                            <Lock size={16} />
+                            Changer le mot de passe
+                        </div>
+
+                        {message && (
+                            <div className={`account-settings-message account-settings-message-${message.type}`}>
+                                {message.text}
+                            </div>
+                        )}
+
+                        <form onSubmit={handleChangePassword}>
+                            <div className="account-settings-form-group">
+                                <label className="account-settings-label" htmlFor="account-settings-current-password">
+                                    Mot de passe actuel
+                                </label>
+                                <input
+                                    id="account-settings-current-password"
+                                    type="password"
+                                    className="account-settings-input"
+                                    placeholder="Entrez votre mot de passe actuel"
+                                    value={currentPassword}
+                                    onChange={(e) => setCurrentPassword(e.target.value)}
+                                    disabled={loading}
+                                />
+                            </div>
+
+                            <div className="account-settings-form-group">
+                                <label className="account-settings-label" htmlFor="account-settings-new-password">
+                                    Nouveau mot de passe
+                                </label>
+                                <input
+                                    id="account-settings-new-password"
+                                    type="password"
+                                    className="account-settings-input"
+                                    placeholder="Entrez votre nouveau mot de passe"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                    disabled={loading}
+                                />
+                            </div>
+
+                            <div className="account-settings-form-group">
+                                <label className="account-settings-label" htmlFor="account-settings-confirm-password">
+                                    Confirmer le nouveau mot de passe
+                                </label>
+                                <input
+                                    id="account-settings-confirm-password"
+                                    type="password"
+                                    className="account-settings-input"
+                                    placeholder="Confirmez votre nouveau mot de passe"
+                                    value={confirmNewPassword}
+                                    onChange={(e) => setConfirmNewPassword(e.target.value)}
+                                    disabled={loading}
+                                />
+                            </div>
+
+                            <button
+                                type="submit"
+                                className="account-settings-btn account-settings-btn-submit"
+                                disabled={loading}
+                            >
+                                {loading ? 'Mise à jour...' : 'Mettre à jour'}
+                            </button>
+                        </form>
+                    </div>
+                </div>
+
+                {/* Footer */}
+                <div className="account-settings-modal-footer">
+                    <button
+                        className="account-settings-btn account-settings-btn-logout"
+                        onClick={onLogout}
+                    >
+                        Se déconnecter
+                    </button>
+                </div>
+            </div>
+        </div>,
+        document.body
+    );
+}

--- a/src/components/Home/HomeLanding.tsx
+++ b/src/components/Home/HomeLanding.tsx
@@ -1,10 +1,10 @@
-import { ArrowRight, CarFront, FilePlus2, FolderClock, LogOut } from "lucide-react";
+import { ArrowRight, CarFront, FilePlus2, FolderClock, UserCircle } from "lucide-react";
 import "./HomeLanding.css";
 
 type HomeLandingProps = {
   onCreateNew?: () => void;
   onOpenHistory?: () => void;
-  onLogout?: () => void;
+  onOpenAccountSettings?: () => void;
 };
 
 /**
@@ -13,7 +13,7 @@ type HomeLandingProps = {
 export default function HomeLanding({
   onCreateNew,
   onOpenHistory,
-  onLogout,
+  onOpenAccountSettings,
 }: HomeLandingProps) {
   return (
     <div className="home-landing">
@@ -29,10 +29,10 @@ export default function HomeLanding({
           <button
             type="button"
             className="home-landing__settings"
-            aria-label="Se déconnecter"
-            onClick={onLogout}
+            aria-label="Paramètres du compte"
+            onClick={onOpenAccountSettings}
           >
-            <LogOut size={22} strokeWidth={2.4} />
+            <UserCircle size={22} strokeWidth={2.4} />
           </button>
         </header>
 

--- a/src/pages/ForgotPasswordPage.test.tsx
+++ b/src/pages/ForgotPasswordPage.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ForgotPasswordPage from './ForgotPasswordPage';
+
+function renderForgotPasswordPage() {
+    return render(
+        <MemoryRouter>
+            <ForgotPasswordPage />
+        </MemoryRouter>
+    );
+}
+
+describe('ForgotPasswordPage', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    it('affiche le titre et le champ email', () => {
+        renderForgotPasswordPage();
+        expect(screen.getByText('Mot de passe oublié')).toBeInTheDocument();
+        expect(screen.getByLabelText('Adresse email')).toBeInTheDocument();
+    });
+
+    it('affiche le lien retour à la connexion', () => {
+        renderForgotPasswordPage();
+        expect(screen.getByText('Retour à la connexion')).toBeInTheDocument();
+    });
+
+    it('affiche un message de succès après envoi réussi', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response);
+
+        renderForgotPasswordPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'user@example.com');
+        await user.click(screen.getByRole('button', { name: /recevoir le lien/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText(/email de réinitialisation a été envoyé/i)
+            ).toBeInTheDocument();
+        });
+        expect(screen.queryByLabelText('Adresse email')).not.toBeInTheDocument();
+    });
+
+    it('affiche une erreur si l\'API renvoie une erreur', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+        renderForgotPasswordPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'user@example.com');
+        await user.click(screen.getByRole('button', { name: /recevoir le lien/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Une erreur s'est produite. Veuillez réessayer.")).toBeInTheDocument();
+        });
+    });
+
+    it('affiche une erreur si le serveur est inaccessible', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+        renderForgotPasswordPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'user@example.com');
+        await user.click(screen.getByRole('button', { name: /recevoir le lien/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Impossible de joindre le serveur.')).toBeInTheDocument();
+        });
+    });
+
+    it('désactive le bouton pendant le chargement', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
+
+        renderForgotPasswordPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'user@example.com');
+        await user.click(screen.getByRole('button', { name: /recevoir le lien/i }));
+
+        expect(screen.getByRole('button', { name: /envoi en cours/i })).toBeDisabled();
+    });
+
+    it('envoie l\'email dans le body de la requête', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response);
+
+        renderForgotPasswordPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'check@example.com');
+        await user.click(screen.getByRole('button', { name: /recevoir le lien/i }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith(
+                'http://localhost:8080/auth/forgot-password',
+                expect.objectContaining({
+                    method: 'POST',
+                    body: JSON.stringify({ email: 'check@example.com' }),
+                })
+            );
+        });
+    });
+});

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,102 @@
+import { useState, type FormEvent } from "react";
+import { Link } from "react-router-dom";
+import { CarFront } from "lucide-react";
+import "./LoginPage.css";
+
+const BACKEND_URL = "http://localhost:8080";
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        setError(null);
+        setLoading(true);
+
+        try {
+            const res = await fetch(`${BACKEND_URL}/auth/forgot-password`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ email }),
+            });
+
+            if (!res.ok) {
+                setError("Une erreur s'est produite. Veuillez réessayer.");
+                return;
+            }
+
+            setSuccess(true);
+            setEmail("");
+        } catch {
+            setError("Impossible de joindre le serveur.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="login-page">
+            <div className="login-card">
+                <div className="login-card__brand">
+                    <span className="login-card__brand-icon">
+                        <CarFront size={22} />
+                    </span>
+                    <span>C15 Fiesta Tour</span>
+                </div>
+
+                <div className="login-card__heading">
+                    <h1 className="login-card__title">Mot de passe oublié</h1>
+                    <p className="login-card__subtitle">Saisissez votre email pour recevoir un lien de réinitialisation</p>
+                </div>
+
+                {!success ? (
+                    <>
+                        <form className="login-form" onSubmit={handleSubmit}>
+                            <div className="login-form__field">
+                                <label className="login-form__label" htmlFor="forgot-email">
+                                    Adresse email
+                                </label>
+                                <input
+                                    id="forgot-email"
+                                    type="email"
+                                    className={`login-form__input${error ? " login-form__input--error" : ""}`}
+                                    placeholder="votre@email.com"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    autoComplete="email"
+                                    required
+                                />
+                            </div>
+
+                            {error && <p className="login-form__error">{error}</p>}
+
+                            <button type="submit" className="login-form__submit" disabled={loading}>
+                                {loading ? "Envoi en cours…" : "Recevoir le lien"}
+                            </button>
+                        </form>
+
+                        <p className="login-form__footer">
+                            <Link className="login-form__link" to="/login">
+                                Retour à la connexion
+                            </Link>
+                        </p>
+                    </>
+                ) : (
+                    <>
+                        <p className="login-form__notice">
+                            Un email de réinitialisation a été envoyé à {email}. Vérifiez votre boîte de réception.
+                        </p>
+                        <p className="login-form__footer">
+                            <Link className="login-form__link" to="/login">
+                                Retour à la connexion
+                            </Link>
+                        </p>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,11 +1,14 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import HomeLanding from "../components/Home/HomeLanding.tsx";
+import { AccountSettingsModal } from "../components/AccountSettings/AccountSettingsModal";
 import {itineraryModel} from "../customObject/Itinerary/ItineraryStore.ts";
 import { useAuth } from "../auth/useAuth";
 
 export default function HomePage() {
   const navigate = useNavigate();
   const { logout } = useAuth();
+  const [accountSettingsOpen, setAccountSettingsOpen] = useState(false);
 
   const handleLogout = () => {
     logout();
@@ -13,13 +16,20 @@ export default function HomePage() {
   };
 
   return (
-    <HomeLanding
-      onCreateNew={() => {
-        itineraryModel.reset();
-        navigate("/planner")
-      }}
-      onOpenHistory={() => navigate("/history")}
-      onLogout={handleLogout}
-    />
+    <>
+      <HomeLanding
+        onCreateNew={() => {
+          itineraryModel.reset();
+          navigate("/planner")
+        }}
+        onOpenHistory={() => navigate("/history")}
+        onOpenAccountSettings={() => setAccountSettingsOpen(true)}
+      />
+      <AccountSettingsModal
+        isOpen={accountSettingsOpen}
+        onClose={() => setAccountSettingsOpen(false)}
+        onLogout={handleLogout}
+      />
+    </>
   );
 }

--- a/src/pages/LoginPage.test.tsx
+++ b/src/pages/LoginPage.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../auth/AuthContext';
+import LoginPage from './LoginPage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderLoginPage(locationState?: { message: string }) {
+    return render(
+        <MemoryRouter initialEntries={[{ pathname: '/login', state: locationState ?? null }]}>
+            <AuthProvider>
+                <LoginPage />
+            </AuthProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('LoginPage', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockNavigate.mockReset();
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    it('affiche le champ email et mot de passe', () => {
+        renderLoginPage();
+        expect(screen.getByLabelText('Adresse email')).toBeInTheDocument();
+        expect(screen.getByLabelText('Mot de passe')).toBeInTheDocument();
+    });
+
+    it('affiche le lien mot de passe oublié', () => {
+        renderLoginPage();
+        expect(screen.getByText('Mot de passe oublié ?')).toBeInTheDocument();
+    });
+
+    it('affiche le lien vers la page inscription', () => {
+        renderLoginPage();
+        expect(screen.getByText('Créer un compte')).toBeInTheDocument();
+    });
+
+    it('affiche le message de notice depuis le state de location', () => {
+        renderLoginPage({ message: 'Compte créé avec succès.' });
+        expect(screen.getByText('Compte créé avec succès.')).toBeInTheDocument();
+    });
+
+    it('connexion réussie → navigue vers /', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ token: 'jwt-token' }),
+        } as Response);
+
+        renderLoginPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'test@example.com');
+        await user.type(screen.getByLabelText('Mot de passe'), 'password123');
+        await user.click(screen.getByRole('button', { name: /se connecter/i }));
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+        });
+        expect(localStorage.getItem('auth_token')).toBe('jwt-token');
+        expect(localStorage.getItem('auth_email')).toBe('test@example.com');
+    });
+
+    it('affiche une erreur si les identifiants sont incorrects', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+        renderLoginPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'bad@example.com');
+        await user.type(screen.getByLabelText('Mot de passe'), 'wrong');
+        await user.click(screen.getByRole('button', { name: /se connecter/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Identifiants incorrects. Veuillez réessayer.')).toBeInTheDocument();
+        });
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('affiche une erreur si le serveur est inaccessible', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+        renderLoginPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'test@example.com');
+        await user.type(screen.getByLabelText('Mot de passe'), 'password');
+        await user.click(screen.getByRole('button', { name: /se connecter/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Impossible de joindre le serveur. Vérifiez votre connexion.')).toBeInTheDocument();
+        });
+    });
+
+    it('désactive le bouton pendant le chargement', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
+
+        renderLoginPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'test@example.com');
+        await user.type(screen.getByLabelText('Mot de passe'), 'password');
+        await user.click(screen.getByRole('button', { name: /se connecter/i }));
+
+        expect(screen.getByRole('button', { name: /connexion en cours/i })).toBeDisabled();
+    });
+
+    it('envoie la requête fetch avec email et mot de passe', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ token: 'jwt' }),
+        } as Response);
+
+        renderLoginPage();
+        await user.type(screen.getByLabelText('Adresse email'), 'user@test.com');
+        await user.type(screen.getByLabelText('Mot de passe'), 'pass');
+        await user.click(screen.getByRole('button', { name: /se connecter/i }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith(
+                'http://localhost:8080/auth/login',
+                expect.objectContaining({
+                    method: 'POST',
+                    body: JSON.stringify({ email: 'user@test.com', password: 'pass' }),
+                })
+            );
+        });
+    });
+});

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -16,7 +16,7 @@ export default function LoginPage() {
     const location = useLocation();
     const state = location.state as LoginLocationState | null;
 
-    const [username, setUsername] = useState("");
+    const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [error, setError] = useState<string | null>(null);
     const [notice, setNotice] = useState<string | null>(state?.message ?? null);
@@ -32,7 +32,7 @@ export default function LoginPage() {
             const res = await fetch(`${BACKEND_URL}/auth/login`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ username, password }),
+                body: JSON.stringify({ email, password }),
             });
 
             if (!res.ok) {
@@ -41,7 +41,7 @@ export default function LoginPage() {
             }
 
             const data = await res.json();
-            login(data.token);
+            login(data.token, email);
             navigate("/", { replace: true });
         } catch {
             setError("Impossible de joindre le serveur. Vérifiez votre connexion.");
@@ -67,17 +67,17 @@ export default function LoginPage() {
 
                 <form className="login-form" onSubmit={handleSubmit}>
                     <div className="login-form__field">
-                        <label className="login-form__label" htmlFor="username">
-                            Identifiant
+                        <label className="login-form__label" htmlFor="email">
+                            Adresse email
                         </label>
                         <input
-                            id="username"
-                            type="text"
+                            id="email"
+                            type="email"
                             className={`login-form__input${error ? " login-form__input--error" : ""}`}
-                            placeholder="Votre identifiant"
-                            value={username}
-                            onChange={(e) => setUsername(e.target.value)}
-                            autoComplete="username"
+                            placeholder="votre@email.com"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            autoComplete="email"
                             required
                         />
                     </div>
@@ -100,6 +100,10 @@ export default function LoginPage() {
 
                     {notice && <p className="login-form__notice">{notice}</p>}
                     {error && <p className="login-form__error">{error}</p>}
+
+                    <Link to="/forgot-password" className="login-form__link">
+                        Mot de passe oublié ?
+                    </Link>
 
                     <button type="submit" className="login-form__submit" disabled={loading}>
                         {loading ? "Connexion en cours…" : "Se connecter"}

--- a/src/pages/RegisterPage.test.tsx
+++ b/src/pages/RegisterPage.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../auth/AuthContext';
+import RegisterPage from './RegisterPage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderRegisterPage() {
+    return render(
+        <MemoryRouter>
+            <AuthProvider>
+                <RegisterPage />
+            </AuthProvider>
+        </MemoryRouter>
+    );
+}
+
+async function fillForm(
+    user: ReturnType<typeof userEvent.setup>,
+    opts: { username?: string; email?: string; password?: string; confirmPassword?: string } = {}
+) {
+    const {
+        username = 'johndoe',
+        email = 'john@example.com',
+        password = 'password123',
+        confirmPassword = 'password123',
+    } = opts;
+    if (username) await user.type(screen.getByLabelText('Identifiant'), username);
+    if (email) await user.type(screen.getByLabelText('Adresse email'), email);
+    if (password) await user.type(screen.getByLabelText('Mot de passe'), password);
+    if (confirmPassword) await user.type(screen.getByLabelText('Confirmer le mot de passe'), confirmPassword);
+}
+
+describe('RegisterPage', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockNavigate.mockReset();
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    it('affiche tous les champs du formulaire', () => {
+        renderRegisterPage();
+        expect(screen.getByLabelText('Identifiant')).toBeInTheDocument();
+        expect(screen.getByLabelText('Adresse email')).toBeInTheDocument();
+        expect(screen.getByLabelText('Mot de passe')).toBeInTheDocument();
+        expect(screen.getByLabelText('Confirmer le mot de passe')).toBeInTheDocument();
+    });
+
+    it('affiche le lien vers la page de connexion', () => {
+        renderRegisterPage();
+        expect(screen.getByText('Se connecter')).toBeInTheDocument();
+    });
+
+    it('affiche une erreur si les mots de passe ne correspondent pas', async () => {
+        const user = userEvent.setup();
+        renderRegisterPage();
+        await fillForm(user, { password: 'password123', confirmPassword: 'different' });
+        await user.click(screen.getByRole('button', { name: /créer mon compte/i }));
+
+        expect(screen.getByText('Les mots de passe ne correspondent pas.')).toBeInTheDocument();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('inscription réussie avec token → navigue vers /', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ token: 'new-token' }),
+        } as Response);
+
+        renderRegisterPage();
+        await fillForm(user);
+        await user.click(screen.getByRole('button', { name: /créer mon compte/i }));
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+        });
+        expect(localStorage.getItem('auth_token')).toBe('new-token');
+    });
+
+    it('inscription réussie sans token → redirige vers /login avec message', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({}),
+        } as Response);
+
+        renderRegisterPage();
+        await fillForm(user);
+        await user.click(screen.getByRole('button', { name: /créer mon compte/i }));
+
+        await waitFor(() => {
+            expect(mockNavigate).toHaveBeenCalledWith('/login', {
+                replace: true,
+                state: { message: 'Compte créé avec succès. Vous pouvez vous connecter.' },
+            });
+        });
+    });
+
+    it('affiche une erreur si le serveur renvoie une erreur', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+        renderRegisterPage();
+        await fillForm(user);
+        await user.click(screen.getByRole('button', { name: /créer mon compte/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Impossible de créer le compte. Vérifiez vos informations.')).toBeInTheDocument();
+        });
+    });
+
+    it('affiche une erreur si le serveur est inaccessible', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+        renderRegisterPage();
+        await fillForm(user);
+        await user.click(screen.getByRole('button', { name: /créer mon compte/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Impossible de joindre le serveur. Vérifiez votre connexion.')).toBeInTheDocument();
+        });
+    });
+
+    it('désactive le bouton pendant le chargement', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
+
+        renderRegisterPage();
+        await fillForm(user);
+        await user.click(screen.getByRole('button', { name: /créer mon compte/i }));
+
+        expect(screen.getByRole('button', { name: /création du compte/i })).toBeDisabled();
+    });
+
+    it('envoie username, email et password dans la requête', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({}),
+        } as Response);
+
+        renderRegisterPage();
+        await fillForm(user, { username: 'jdoe', email: 'jdoe@test.com', password: 'p', confirmPassword: 'p' });
+        await user.click(screen.getByRole('button', { name: /créer mon compte/i }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith(
+                'http://localhost:8080/auth/register',
+                expect.objectContaining({
+                    body: JSON.stringify({ username: 'jdoe', email: 'jdoe@test.com', password: 'p' }),
+                })
+            );
+        });
+    });
+});

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -15,6 +15,7 @@ export default function RegisterPage() {
     const navigate = useNavigate();
 
     const [username, setUsername] = useState("");
+    const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
     const [error, setError] = useState<string | null>(null);
@@ -35,7 +36,7 @@ export default function RegisterPage() {
             const res = await fetch(`${BACKEND_URL}/auth/register`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ username, password }),
+                body: JSON.stringify({ username, email, password }),
             });
 
             if (!res.ok) {
@@ -46,7 +47,7 @@ export default function RegisterPage() {
             const data: RegisterResponse = await res.json().catch(() => ({}));
 
             if (data.token) {
-                login(data.token);
+                login(data.token, email);
                 navigate("/", { replace: true });
                 return;
             }
@@ -90,6 +91,22 @@ export default function RegisterPage() {
                             value={username}
                             onChange={(e) => setUsername(e.target.value)}
                             autoComplete="username"
+                            required
+                        />
+                    </div>
+
+                    <div className="login-form__field">
+                        <label className="login-form__label" htmlFor="register-email">
+                            Adresse email
+                        </label>
+                        <input
+                            id="register-email"
+                            type="email"
+                            className={`login-form__input${error ? " login-form__input--error" : ""}`}
+                            placeholder="votre@email.com"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            autoComplete="email"
                             required
                         />
                     </div>

--- a/src/pages/ResetPasswordPage.test.tsx
+++ b/src/pages/ResetPasswordPage.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import ResetPasswordPage from './ResetPasswordPage';
+
+function renderWithToken(token?: string) {
+    const url = token ? `/reset-password?token=${token}` : '/reset-password';
+    return render(
+        <MemoryRouter initialEntries={[url]}>
+            <ResetPasswordPage />
+        </MemoryRouter>
+    );
+}
+
+describe('ResetPasswordPage', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    it('affiche un message d\'erreur si aucun token dans l\'URL', () => {
+        renderWithToken();
+        expect(screen.getByText('Lien invalide')).toBeInTheDocument();
+        expect(screen.getByText(/lien invalide ou expiré/i)).toBeInTheDocument();
+        expect(screen.getByText('Retour à la réinitialisation')).toBeInTheDocument();
+    });
+
+    it('affiche le formulaire si un token est présent', () => {
+        renderWithToken('valid-token-abc');
+        expect(screen.getByText('Réinitialiser le mot de passe')).toBeInTheDocument();
+        expect(screen.getByLabelText('Nouveau mot de passe')).toBeInTheDocument();
+        expect(screen.getByLabelText('Confirmer le mot de passe')).toBeInTheDocument();
+    });
+
+    it('affiche une erreur si les mots de passe ne correspondent pas', async () => {
+        const user = userEvent.setup();
+        renderWithToken('abc123');
+
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'password1');
+        await user.type(screen.getByLabelText('Confirmer le mot de passe'), 'password2');
+        await user.click(screen.getByRole('button', { name: /réinitialiser/i }));
+
+        expect(screen.getByText('Les mots de passe ne correspondent pas.')).toBeInTheDocument();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('réinitialisation réussie → affiche message de succès', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response);
+
+        renderWithToken('valid-token');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpass123');
+        await user.type(screen.getByLabelText('Confirmer le mot de passe'), 'newpass123');
+        await user.click(screen.getByRole('button', { name: /réinitialiser/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Mot de passe réinitialisé avec succès !')).toBeInTheDocument();
+        });
+        expect(screen.getByText('Se connecter')).toBeInTheDocument();
+    });
+
+    it('affiche une erreur si l\'API échoue', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+        renderWithToken('valid-token');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpass123');
+        await user.type(screen.getByLabelText('Confirmer le mot de passe'), 'newpass123');
+        await user.click(screen.getByRole('button', { name: /réinitialiser/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Impossible de réinitialiser le mot de passe. Veuillez réessayer.')
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('affiche une erreur si le serveur est inaccessible', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
+
+        renderWithToken('valid-token');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpass123');
+        await user.type(screen.getByLabelText('Confirmer le mot de passe'), 'newpass123');
+        await user.click(screen.getByRole('button', { name: /réinitialiser/i }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText('Impossible de joindre le serveur. Vérifiez votre connexion.')
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('désactive le bouton pendant le chargement', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
+
+        renderWithToken('valid-token');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'newpass123');
+        await user.type(screen.getByLabelText('Confirmer le mot de passe'), 'newpass123');
+        await user.click(screen.getByRole('button', { name: /réinitialiser/i }));
+
+        expect(screen.getByRole('button', { name: /traitement en cours/i })).toBeDisabled();
+    });
+
+    it('envoie le token et le nouveau mot de passe dans la requête', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response);
+
+        renderWithToken('mytoken');
+        await user.type(screen.getByLabelText('Nouveau mot de passe'), 'secret');
+        await user.type(screen.getByLabelText('Confirmer le mot de passe'), 'secret');
+        await user.click(screen.getByRole('button', { name: /réinitialiser/i }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith(
+                'http://localhost:8080/auth/reset-password',
+                expect.objectContaining({
+                    body: JSON.stringify({ token: 'mytoken', newPassword: 'secret' }),
+                })
+            );
+        });
+    });
+});

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,140 @@
+import { useState, type FormEvent } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { CarFront } from "lucide-react";
+import "./LoginPage.css";
+
+const BACKEND_URL = "http://localhost:8080";
+
+export default function ResetPasswordPage() {
+    const [searchParams] = useSearchParams();
+    const token = searchParams.get("token");
+
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [error, setError] = useState<string | null>(null);
+    const [success, setSuccess] = useState(false);
+    const [loading, setLoading] = useState(false);
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault();
+        setError(null);
+
+        if (newPassword !== confirmPassword) {
+            setError("Les mots de passe ne correspondent pas.");
+            return;
+        }
+
+        setLoading(true);
+
+        try {
+            const res = await fetch(`${BACKEND_URL}/auth/reset-password`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ token, newPassword }),
+            });
+
+            if (!res.ok) {
+                setError("Impossible de réinitialiser le mot de passe. Veuillez réessayer.");
+                return;
+            }
+
+            setSuccess(true);
+        } catch {
+            setError("Impossible de joindre le serveur. Vérifiez votre connexion.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="login-page">
+            <div className="login-card">
+                <div className="login-card__brand">
+                    <span className="login-card__brand-icon">
+                        <CarFront size={22} />
+                    </span>
+                    <span>C15 Fiesta Tour</span>
+                </div>
+
+                {!token || token.trim() === "" ? (
+                    <>
+                        <div className="login-card__heading">
+                            <h1 className="login-card__title">Lien invalide</h1>
+                        </div>
+
+                        <div className="login-form__error">
+                            Lien invalide ou expiré. Veuillez recommencer depuis la page mot de passe
+                            oublié.
+                        </div>
+
+                        <p className="login-form__footer">
+                            <Link className="login-form__link" to="/forgot-password">
+                                Retour à la réinitialisation
+                            </Link>
+                        </p>
+                    </>
+                ) : success ? (
+                    <>
+                        <div className="login-card__heading">
+                            <h1 className="login-card__title">Mot de passe réinitialisé</h1>
+                        </div>
+
+                        <div className="login-form__notice">Mot de passe réinitialisé avec succès !</div>
+
+                        <p className="login-form__footer">
+                            <Link className="login-form__link" to="/login">
+                                Se connecter
+                            </Link>
+                        </p>
+                    </>
+                ) : (
+                    <>
+                        <div className="login-card__heading">
+                            <h1 className="login-card__title">Réinitialiser le mot de passe</h1>
+                        </div>
+
+                        <form className="login-form" onSubmit={handleSubmit}>
+                            <div className="login-form__field">
+                                <label className="login-form__label" htmlFor="newPassword">
+                                    Nouveau mot de passe
+                                </label>
+                                <input
+                                    id="newPassword"
+                                    type="password"
+                                    className={`login-form__input${error ? " login-form__input--error" : ""}`}
+                                    placeholder="Entrez votre nouveau mot de passe"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                    autoComplete="new-password"
+                                    required
+                                />
+                            </div>
+
+                            <div className="login-form__field">
+                                <label className="login-form__label" htmlFor="confirmPassword">
+                                    Confirmer le mot de passe
+                                </label>
+                                <input
+                                    id="confirmPassword"
+                                    type="password"
+                                    className={`login-form__input${error ? " login-form__input--error" : ""}`}
+                                    placeholder="Confirmez votre nouveau mot de passe"
+                                    value={confirmPassword}
+                                    onChange={(e) => setConfirmPassword(e.target.value)}
+                                    autoComplete="new-password"
+                                    required
+                                />
+                            </div>
+
+                            {error && <p className="login-form__error">{error}</p>}
+
+                            <button type="submit" className="login-form__submit" disabled={loading}>
+                                {loading ? "Traitement en cours…" : "Réinitialiser"}
+                            </button>
+                        </form>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

- **Login avec email** : le champ identifiant devient un champ email (`type="email"`), l'API reçoit désormais `{ email, password }`. L'email est persisté en `localStorage` et exposé via `AuthContext`.
- **Paramètres de compte** : bouton `UserCircle` dans le header de la page d'accueil ouvre un modal `AccountSettingsModal` — affiche l'email en lecture seule, formulaire de changement de mot de passe (POST `/auth/change-password`), et bouton de déconnexion.
- **Mot de passe oublié** : nouvelle route publique `/forgot-password` (formulaire email → POST `/auth/forgot-password`) et `/reset-password?token=...` (nouveau mot de passe → POST `/auth/reset-password`). Lien "Mot de passe oublié ?" ajouté dans la page de connexion.

## Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `src/auth/authContextDef.ts` | Ajout `email`, `setEmail` au type |
| `src/auth/AuthContext.tsx` | Stockage email en localStorage |
| `src/pages/LoginPage.tsx` | Champ email + lien forgot-password |
| `src/pages/RegisterPage.tsx` | Champ email à l'inscription |
| `src/pages/ForgotPasswordPage.tsx` | Nouvelle page (public) |
| `src/pages/ResetPasswordPage.tsx` | Nouvelle page (public, lit `?token`) |
| `src/components/AccountSettings/AccountSettingsModal.tsx` | Nouveau modal compte |
| `src/components/AccountSettings/AccountSettingsModal.css` | Styles modal compte |
| `src/components/Home/HomeLanding.tsx` | Bouton UserCircle → paramètres compte |
| `src/pages/HomePage.tsx` | State modal + AccountSettingsModal |
| `src/App.tsx` | Routes `/forgot-password` et `/reset-password` |

## Test plan

- [ ] Inscription avec email → email stocké en context
- [ ] Connexion avec email/mdp → redirection `/`
- [ ] Bouton UserCircle en page d'accueil → modal s'ouvre
- [ ] Changer mot de passe dans le modal (success + erreur)
- [ ] Déconnexion depuis le modal
- [ ] Lien "Mot de passe oublié ?" → `/forgot-password`
- [ ] Formulaire forgot-password → message de succès
- [ ] URL `/reset-password?token=abc` → formulaire reset
- [ ] URL `/reset-password` sans token → message d'erreur + lien retour
- [ ] `npx tsc --noEmit` → 0 erreur