### PR TITLE
ci: release workflow — snapshot bump + main→dev sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "dev" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "dev", "main" ]
 
 jobs:
   sonarqube:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   release-please:
+    # Skip on snapshot version bumps — chore commits don't trigger release-please anyway,
+    # but this guard makes the intent explicit and prevents edge-case garbage PRs.
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version to')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,71 @@
+name: Create Snapshot PR
+
+# Fires when release-please publishes a GitHub Release (i.e. after the Release PR is merged
+# and the tag is created). Creates a PR that bumps package.json to the next patch-snapshot
+# version so dev work-in-progress is clearly marked.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-snapshot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Compute snapshot version
+        id: version
+        run: |
+          RELEASED="${{ github.event.release.tag_name }}"
+          RELEASED="${RELEASED#v}"
+          MAJOR=$(echo "$RELEASED" | cut -d. -f1)
+          MINOR=$(echo "$RELEASED" | cut -d. -f2)
+          PATCH=$(echo "$RELEASED" | cut -d. -f3 | cut -d- -f1)
+          NEXT_PATCH=$((PATCH + 1))
+          SNAPSHOT="${MAJOR}.${MINOR}.${NEXT_PATCH}-snapshot"
+          echo "snapshot=${SNAPSHOT}" >> "$GITHUB_OUTPUT"
+          echo "branch=chore/bump-to-${SNAPSHOT}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create snapshot branch and bump version
+        run: |
+          git checkout -b "${{ steps.version.outputs.branch }}"
+          # Updates both package.json and package-lock.json, no git tag
+          npm version "${{ steps.version.outputs.snapshot }}" --no-git-tag-version
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${{ steps.version.outputs.snapshot }}"
+          git push origin "${{ steps.version.outputs.branch }}"
+
+      - name: Ensure snapshot label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh label create snapshot --color 0075ca --description "Snapshot version bump" --force
+
+      - name: Open snapshot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.version.outputs.branch }}" \
+            --title "chore: bump version to ${{ steps.version.outputs.snapshot }}" \
+            --body "Automatic snapshot version bump after release \`${{ github.event.release.tag_name }}\`." \
+            --label snapshot

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,49 @@
+name: Sync main → dev
+
+# After the snapshot PR is merged into main, automatically open a PR to bring
+# the release commit + snapshot version bump back into dev.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-sync-pr:
+    if: >
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'snapshot')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure sync label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh label create sync --color e4e669 --description "Sync main to dev" --force
+
+      - name: Open sync PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Bail out if a sync PR is already open
+          EXISTING=$(gh pr list --base dev --head main --state open --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Sync PR #$EXISTING already open, skipping."
+            exit 0
+          fi
+
+          gh pr create \
+            --base dev \
+            --head main \
+            --title "chore: sync main → dev" \
+            --body "Automatic sync of main to dev after snapshot version bump." \
+            --label sync


### PR DESCRIPTION
## Résumé

Met en place le workflow de release complet : `feature/xxx → dev → main → release → snapshot → sync`.

### Ce qui change

| Fichier | Modification |
|---|---|
| `ci.yml` | CI tourne aussi sur les PRs vers `main` (Release PR, snapshot PR) |
| `release.yml` | Guard `if` explicite — skip si le commit est un bump snapshot, pas de PR garbage |
| `snapshot.yml` | **Nouveau** — se déclenche sur `release: published`, crée une PR `chore: bump version to X.Y.Z-snapshot` vers `main` avec le label `snapshot` |
| `sync.yml` | **Nouveau** — se déclenche quand une PR labellisée `snapshot` est mergée dans `main`, crée automatiquement une PR `main → dev` avec le label `sync` |

### Cycle complet

```
feature/xxx ──PR──▶ dev ──PR──▶ main
                                  │
                          release-please
                                  │
                          Release PR mergée → tag vX.Y.Z créé
                                  │
                          snapshot.yml déclenché
                                  │
                          Snapshot PR (chore: bump to X.Y.Z+1-snapshot) → main
                          release.yml SKIPPÉ (guard + chore commit)
                                  │
                          sync.yml déclenché
                                  │
                          Sync PR (main → dev) créée automatiquement
                                  │
                                done ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)