### PR TITLE
fix: saisie d'espaces dans les noms de segment/étape (#146)

### DIFF
--- a/src/components/ClickInput.test.tsx
+++ b/src/components/ClickInput.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ClickInput from './ClickInput';
+
+function renderInput(props: Partial<React.ComponentProps<typeof ClickInput>> = {}) {
+    const setter = props.setter ?? vi.fn();
+    render(
+        <ClickInput
+            currentStr={props.currentStr ?? 'Segment'}
+            setter={setter}
+            Tag={props.Tag ?? 'h2'}
+            className={props.className ?? 'segmentTitle'}
+            isDesactivated={props.isDesactivated ?? false}
+        />
+    );
+    return { setter };
+}
+
+describe('ClickInput', () => {
+    it('affiche la valeur courante', () => {
+        renderInput({ currentStr: 'Mon segment' });
+        expect(screen.getByText('Mon segment')).toBeInTheDocument();
+    });
+
+    it('passe en mode édition au clic', async () => {
+        const user = userEvent.setup();
+        renderInput();
+        await user.click(screen.getByRole('button'));
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('enregistre un nom contenant un espace', async () => {
+        const user = userEvent.setup();
+        const { setter } = renderInput({ currentStr: 'Segment' });
+
+        await user.click(screen.getByRole('button'));
+        const input = screen.getByRole('textbox');
+        await user.clear(input);
+        await user.type(input, 'Aire de repos{Enter}');
+
+        expect(setter).toHaveBeenCalledWith('Aire de repos');
+    });
+
+    it('ignore une saisie composée uniquement d\'espaces', async () => {
+        const user = userEvent.setup();
+        const { setter } = renderInput({ currentStr: 'Segment' });
+
+        await user.click(screen.getByRole('button'));
+        const input = screen.getByRole('textbox');
+        await user.clear(input);
+        await user.type(input, '   {Enter}');
+
+        expect(setter).not.toHaveBeenCalled();
+    });
+
+    it('stoppe la propagation clavier vers un parent draggable (fix dnd-kit)', async () => {
+        const user = userEvent.setup();
+        const onParentKeyDown = vi.fn();
+        const setter = vi.fn();
+        render(
+            <div onKeyDown={onParentKeyDown}>
+                <ClickInput
+                    currentStr="Segment"
+                    setter={setter}
+                    Tag="h2"
+                    className="segmentTitle"
+                    isDesactivated={false}
+                />
+            </div>
+        );
+
+        await user.click(screen.getByRole('button'));
+        const input = screen.getByRole('textbox');
+        await user.type(input, ' ');
+
+        expect(onParentKeyDown).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/ClickInput.tsx
+++ b/src/components/ClickInput.tsx
@@ -33,6 +33,7 @@ export default function ClickInput({ currentStr, setter, Tag, className, isDesac
     const [showTooltip, setShowTooltip] = useState(false);
 
     const tooltipTimerRef = useRef<number | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
 
     function clearTooltipTimer() {
         if (tooltipTimerRef.current !== null) {
@@ -64,6 +65,13 @@ export default function ClickInput({ currentStr, setter, Tag, className, isDesac
     useEffect(() => {
         setText(currentStr);
     }, [currentStr]);
+
+    useEffect(() => {
+        if (isInput && inputRef.current) {
+            inputRef.current.focus();
+            inputRef.current.select();
+        }
+    }, [isInput]);
 
     /**
      * Arrête le mode édition de la balise,
@@ -135,6 +143,7 @@ export default function ClickInput({ currentStr, setter, Tag, className, isDesac
         >
             {isInput ? (
                 <input
+                    ref={inputRef}
                     type={"text"}
                     value={text}
                     onChange={(e) => setText(e.target.value)}

--- a/src/components/ClickInput.tsx
+++ b/src/components/ClickInput.tsx
@@ -90,8 +90,11 @@ export default function ClickInput({ currentStr, setter, Tag, className, isDesac
     });
 
     /**
-     * Gère la pression de touche Entrée lors de l'édition de l'input
-     * Si c'est la touche "Entrée" on appelle stopInput()
+     * Gère la pression de touche lors de l'édition de l'input.
+     * stopPropagation empêche le capteur clavier de dnd-kit (parent draggable)
+     * d'intercepter la barre d'espace, qui sinon démarre un drag au lieu de
+     * s'insérer dans le nom du segment/étape.
+     * Si c'est la touche "Entrée" on appelle stopInput().
      * @param event
      */
     function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {

--- a/src/components/ClickInput.tsx
+++ b/src/components/ClickInput.tsx
@@ -72,7 +72,7 @@ export default function ClickInput({ currentStr, setter, Tag, className, isDesac
     function stopInput() {
         if (isInput) {
             setIsInput(false);
-            if (text == " " || text.length == 0) {
+            if (text.trim().length === 0) {
                 setText(currentStr);
             } else {
                 setter(text);
@@ -95,6 +95,7 @@ export default function ClickInput({ currentStr, setter, Tag, className, isDesac
      * @param event
      */
     function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+        event.stopPropagation();
         if (event.key === "Enter") {
             stopInput();
         }
@@ -135,6 +136,7 @@ export default function ClickInput({ currentStr, setter, Tag, className, isDesac
                     value={text}
                     onChange={(e) => setText(e.target.value)}
                     onKeyDown={handleKeyDown}
+                    onPointerDown={(e) => e.stopPropagation()}
                     className={className}
                     style={{
                         background: "#ffffff26",


### PR DESCRIPTION
@
## Contexte
Closes #146

Impossible de saisir un espace lors du renommage dun segment ou dune étape dans le panneau.

## Cause
Les lignes draggables (`SortableStepHeader`, `SortablePDP`) étalent les `listeners` de dnd-kit sur leur `div`. Le capteur clavier de dnd-kit utilise la barre despace pour démarrer un drag : lévénement `keydown` remontait depuis le champ dédition (`ClickInput`) jusquau parent draggable, qui faisait `preventDefault()` sur lespace — celui-ci ne sinsérait donc jamais dans le nom.

## Correctif
- `stopPropagation()` sur le `keydown` (et `pointerdown`) de linput de `ClickInput` pour isoler lédition du capteur dnd-kit.
- Garde de saisie vide durcie : `text.trim().length === 0` (au lieu de `text == " "`) pour couvrir toute saisie blanche.
- UX : autofocus + sélection du texte à lentrée en mode édition.

## Tests
`ClickInput.test.tsx` : valeur affichée, passage en édition, enregistrement dun nom avec espace, rejet dune saisie blanche, non-propagation clavier vers le parent draggable.
@