### PR TITLE
feat: ligne pause entre les segments (#144)

### DIFF
--- a/src/components/Panels/DragNDrop/PauseLine.test.tsx
+++ b/src/components/Panels/DragNDrop/PauseLine.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PauseLine from './PauseLine';
+
+describe('PauseLine', () => {
+    it('affiche le libellé Pause', () => {
+        render(<PauseLine durationSeconds={30 * 60} />);
+        expect(screen.getByText('Pause')).toBeInTheDocument();
+    });
+
+    it('affiche la durée formatée de la pause', () => {
+        render(<PauseLine durationSeconds={30 * 60} />);
+        expect(screen.getByText('0H 30MIN')).toBeInTheDocument();
+    });
+
+    it('affiche une durée en heures et minutes', () => {
+        render(<PauseLine durationSeconds={(60 + 45) * 60} />);
+        expect(screen.getByText('1H 45MIN')).toBeInTheDocument();
+    });
+});

--- a/src/components/Panels/DragNDrop/PauseLine.tsx
+++ b/src/components/Panels/DragNDrop/PauseLine.tsx
@@ -11,8 +11,10 @@ type Props = {
  * @param durationSeconds durée de la pause en secondes (breakDuration du segment)
  */
 export default function PauseLine({ durationSeconds }: Props) {
+    const label = `Pause de ${formatTotalPauseDuration(durationSeconds).trim()}`;
+
     return (
-        <div className={"pause-line"}>
+        <div className={"pause-line"} title={label} aria-label={label}>
             <span className={"pause-line-label"}>
                 <Coffee className={"pause-line-icon"} aria-hidden={true} />
                 Pause

--- a/src/components/Panels/DragNDrop/PauseLine.tsx
+++ b/src/components/Panels/DragNDrop/PauseLine.tsx
@@ -1,0 +1,25 @@
+import { Coffee } from "lucide-react";
+import "../Panels.css";
+import { formatTotalPauseDuration } from "../infoPanelUtils.ts";
+
+type Props = {
+    durationSeconds: number;
+};
+
+/**
+ * Ligne affichant la pause d'un segment, intercalée entre deux segments
+ * @param durationSeconds durée de la pause en secondes (breakDuration du segment)
+ */
+export default function PauseLine({ durationSeconds }: Props) {
+    return (
+        <div className={"pause-line"}>
+            <span className={"pause-line-label"}>
+                <Coffee className={"pause-line-icon"} aria-hidden={true} />
+                Pause
+            </span>
+            <span className={"pause-line-value"}>
+                {formatTotalPauseDuration(durationSeconds)}
+            </span>
+        </div>
+    );
+}

--- a/src/components/Panels/DragNDrop/StepList.tsx
+++ b/src/components/Panels/DragNDrop/StepList.tsx
@@ -12,9 +12,11 @@ import {
     verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 
+import { Fragment } from "react";
 import type {Itinerary, Segment} from "../../../customObject/Itinerary/types.ts";
 import SortableCategory from "./SortableCategory";
 import SortablePDP from "./SortablePDP.tsx";
+import PauseLine from "./PauseLine.tsx";
 import {type DndProps, useDragNDrop} from "./UseDragNDrop.tsx";
 import {useItinerary} from "../../../customObject/Itinerary/UseItinerary.ts";
 import {itineraryModel} from "../../../customObject/Itinerary/ItineraryStore.ts";
@@ -42,12 +44,16 @@ export default function StepList() {
                 strategy={verticalListSortingStrategy}
             >
                 {itinerary.segments.map((cat: Segment) =>
-                    <SortableCategory
-                        key={cat.id}
-                        visible={!(cat.id == dnd.activeCat?.id)}
-                        category={cat}
-                        idActiveItem={dnd.activeItem?.id ? dnd.activeItem.id : null}
-                    />
+                    <Fragment key={cat.id}>
+                        <SortableCategory
+                            visible={!(cat.id == dnd.activeCat?.id)}
+                            category={cat}
+                            idActiveItem={dnd.activeItem?.id ? dnd.activeItem.id : null}
+                        />
+                        {!cat.isStartEnd && (cat.content.breakDuration ?? 0) > 0 && (
+                            <PauseLine durationSeconds={cat.content.breakDuration ?? 0} />
+                        )}
+                    </Fragment>
             )}
             </SortableContext>
             <DragOverlay>

--- a/src/components/Panels/InfoPanel.test.ts
+++ b/src/components/Panels/InfoPanel.test.ts
@@ -12,4 +12,8 @@ describe("formatTotalPauseDuration()", () => {
   it("formate plusieurs pauses cumulees", () => {
     expect(formatTotalPauseDuration((60 + 15) * 60, units)).toBe("1H 15MIN ");
   });
+
+  it("utilise les unites par defaut quand aucune n'est fournie", () => {
+    expect(formatTotalPauseDuration(30 * 60)).toBe("0H 30MIN ");
+  });
 });

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -714,6 +714,11 @@ h3, .stepTitle {
     background: #BB487C14;
     border: 1px dashed #BB487C66;
     width: fit-content;
+    transition: background 0.15s ease;
+}
+
+.pause-line:hover {
+    background: #BB487C26;
 }
 
 .pause-line-label {

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -703,6 +703,43 @@ h3, .stepTitle {
     margin-top: clamp(2px, 0.4vh, 4px);
 }
 
+.pause-line {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: clamp(4px, 0.8vh, 8px) auto;
+    padding: clamp(3px, 0.6vh, 6px) clamp(10px, 2vw, 16px);
+    border-radius: 999px;
+    background: #BB487C14;
+    border: 1px dashed #BB487C66;
+    width: fit-content;
+}
+
+.pause-line-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(9px, 1.6vw, 12px);
+    font-weight: 600;
+    color: #BB487C;
+}
+
+.pause-line-icon {
+    width: clamp(11px, 1.8vw, 14px);
+    height: clamp(11px, 1.8vw, 14px);
+    stroke-width: 2.5;
+    flex: 0 0 auto;
+}
+
+.pause-line-value {
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(10px, 1.8vw, 13px);
+    font-weight: 800;
+    color: #BB487C;
+}
+
 .time-row {
     display: flex;
     justify-content: space-between;

--- a/src/components/Panels/infoPanelUtils.ts
+++ b/src/components/Panels/infoPanelUtils.ts
@@ -1,7 +1,13 @@
 import { TimeSpan, TimespanOffset, type unitTimeSpan } from "../../customObject/TimeSpan.ts";
 
+/** Libellés d'unités partagés pour l'affichage des pauses (InfoPanel et PauseLine). */
 export const PAUSE_UNITS: unitTimeSpan = { days: "J ", hours: "H ", minutes: "MIN ", seconds: "S ", milliseconds: "MS " };
 
+/**
+ * Formate une durée de pause exprimée en secondes en chaîne lisible (ex. "30 MIN").
+ * @param totalPauseSeconds durée de la pause en secondes
+ * @param units libellés d'unités à utiliser (PAUSE_UNITS par défaut)
+ */
 export function formatTotalPauseDuration(totalPauseSeconds: number, units: unitTimeSpan = PAUSE_UNITS): string {
     return new TimeSpan(totalPauseSeconds * 1000).toFStr(TimespanOffset.MINUTES, units);
 }

--- a/src/components/Panels/infoPanelUtils.ts
+++ b/src/components/Panels/infoPanelUtils.ts
@@ -1,5 +1,7 @@
 import { TimeSpan, TimespanOffset, type unitTimeSpan } from "../../customObject/TimeSpan.ts";
 
-export function formatTotalPauseDuration(totalPauseSeconds: number, units: unitTimeSpan): string {
+export const PAUSE_UNITS: unitTimeSpan = { days: "J ", hours: "H ", minutes: "MIN ", seconds: "S ", milliseconds: "MS " };
+
+export function formatTotalPauseDuration(totalPauseSeconds: number, units: unitTimeSpan = PAUSE_UNITS): string {
     return new TimeSpan(totalPauseSeconds * 1000).toFStr(TimespanOffset.MINUTES, units);
 }


### PR DESCRIPTION
@
## Contexte
Closes #144

Les pauses étaient configurables (durée par segment) et leur total saffichait dans `InfoPanel`, mais aucune pause nétait visible dans la liste des segments du panneau.

## Changements
- Nouveau composant `PauseLine` (icône café + durée) affiché entre les segments, après chaque segment ayant une pause (`breakDuration > 0`).
- Intégration dans `StepList` via un `Fragment` ; la ligne nest pas un élément draggable (hors `SortableContext` items).
- Mutualisation du formatage des pauses dans `infoPanelUtils` : constante partagée `PAUSE_UNITS` et unités par défaut sur `formatTotalPauseDuration`.
- Style dédié `.pause-line` (pastille pointillée aux couleurs de lapp, survol).

## Tests
- `PauseLine.test.tsx` : libellé, durée formatée (minutes et heures+minutes).
- `InfoPanel.test.ts` : nouvelle assertion sur les unités par défaut.
@