### PR TITLE
feat: adresse réelle au clic sur la carte (géocodage inverse) (#143)

### DIFF
--- a/src/components/Map/MapClickHandler.test.tsx
+++ b/src/components/Map/MapClickHandler.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+type ClickEvent = { latlng: { lat: number; lng: number } };
+let capturedHandlers: { click?: (e: ClickEvent) => void } = {};
+
+vi.mock('react-leaflet', () => ({
+    useMapEvents: (handlers: { click?: (e: ClickEvent) => void }) => {
+        capturedHandlers = handlers;
+        return null;
+    },
+}));
+
+const addStep = vi.fn();
+const addSegment = vi.fn();
+const renameStep = vi.fn();
+let mockItinerary: { segments: Array<{ id: string; isStartEnd: boolean }> };
+
+vi.mock('../../customObject/Itinerary/ItineraryStore', () => ({
+    itineraryModel: {
+        store: {},
+        addStep: (...args: unknown[]) => addStep(...args),
+        addSegment: (...args: unknown[]) => addSegment(...args),
+        renameStep: (...args: unknown[]) => renameStep(...args),
+    },
+}));
+
+vi.mock('../../customObject/Itinerary/UseItinerary', () => ({
+    useItinerary: () => mockItinerary,
+}));
+
+const reverseGeocode = vi.fn();
+vi.mock('../../customObject/Search/geocode', () => ({
+    reverseGeocode: (...args: unknown[]) => reverseGeocode(...args),
+}));
+
+import MapClickHandler from './MapClickHandler';
+
+describe('MapClickHandler', () => {
+    beforeEach(() => {
+        capturedHandlers = {};
+        addStep.mockClear();
+        addSegment.mockClear();
+        renameStep.mockClear();
+        reverseGeocode.mockReset();
+    });
+
+    it("ajoute une étape avec les coordonnées puis l'adresse géocodée", async () => {
+        mockItinerary = { segments: [{ id: 'seg-1', isStartEnd: false }] };
+        reverseGeocode.mockResolvedValue('12 Rue de la Paix, Paris');
+        render(<MapClickHandler />);
+
+        capturedHandlers.click!({ latlng: { lat: 48.86, lng: 2.33 } });
+
+        expect(addStep).toHaveBeenCalledWith(
+            'seg-1',
+            expect.objectContaining({
+                content: expect.objectContaining({
+                    title: '48.860000 2.330000',
+                    location: { lat: 48.86, lon: 2.33 },
+                }),
+            })
+        );
+        await waitFor(() =>
+            expect(renameStep).toHaveBeenCalledWith('seg-1', expect.any(String), '12 Rue de la Paix, Paris')
+        );
+    });
+
+    it('crée un segment quand aucun segment régulier', () => {
+        mockItinerary = { segments: [] };
+        reverseGeocode.mockResolvedValue(null);
+        render(<MapClickHandler />);
+
+        capturedHandlers.click!({ latlng: { lat: 1, lng: 2 } });
+
+        expect(addSegment).toHaveBeenCalled();
+        expect(addStep).toHaveBeenCalled();
+    });
+
+    it('conserve les coordonnées quand le géocodage échoue', async () => {
+        mockItinerary = { segments: [{ id: 'seg-1', isStartEnd: false }] };
+        reverseGeocode.mockResolvedValue(null);
+        render(<MapClickHandler />);
+
+        capturedHandlers.click!({ latlng: { lat: 48.86, lng: 2.33 } });
+
+        await waitFor(() => expect(reverseGeocode).toHaveBeenCalled());
+        expect(renameStep).not.toHaveBeenCalled();
+    });
+
+    it('ignore une erreur réseau du géocodage sans planter', async () => {
+        mockItinerary = { segments: [{ id: 'seg-1', isStartEnd: false }] };
+        reverseGeocode.mockRejectedValue(new Error('network'));
+        render(<MapClickHandler />);
+
+        capturedHandlers.click!({ latlng: { lat: 48.86, lng: 2.33 } });
+
+        await waitFor(() => expect(reverseGeocode).toHaveBeenCalled());
+        expect(renameStep).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/Map/MapClickHandler.tsx
+++ b/src/components/Map/MapClickHandler.tsx
@@ -3,10 +3,13 @@ import { itineraryModel } from "../../customObject/Itinerary/ItineraryStore.ts";
 import { useItinerary } from "../../customObject/Itinerary/UseItinerary.ts";
 import type { Segment } from "../../customObject/Itinerary/types.ts";
 import { TimeSpan } from "../../customObject/TimeSpan.ts";
+import { reverseGeocode } from "../../customObject/Search/geocode.ts";
 
 /**
  * Gère les clics sur la carte pour créer une nouvelle étape
- * L'étape est ajoutée au dernier segment, qui est créé si nécessaire
+ * L'étape est ajoutée au dernier segment, qui est créé si nécessaire.
+ * Le libellé affiche d'abord les coordonnées puis est remplacé par l'adresse
+ * réelle obtenue par géocodage inverse (les coordonnées restent en cas d'échec).
  */
 export default function MapClickHandler() {
     const itinerary = useItinerary(itineraryModel.store);
@@ -40,8 +43,9 @@ export default function MapClickHandler() {
                 targetSegmentId = newSegment.id;
             }
 
+            const stepId = "mapclick" + new Date().toISOString();
             itineraryModel.addStep(targetSegmentId, {
-                id: "mapclick" + new Date().toISOString(),
+                id: stepId,
                 content: {
                     title,
                     duration: new TimeSpan(),
@@ -49,6 +53,16 @@ export default function MapClickHandler() {
                 },
                 isDefaultSegStart: false,
             });
+
+            reverseGeocode(lat, lng)
+                .then((address) => {
+                    if (address) {
+                        itineraryModel.renameStep(targetSegmentId, stepId, address);
+                    }
+                })
+                .catch(() => {
+                    // Géocodage indisponible : on conserve les coordonnées comme libellé.
+                });
         },
     });
 

--- a/src/components/Search/useSearchBarLogic.ts
+++ b/src/components/Search/useSearchBarLogic.ts
@@ -12,6 +12,7 @@ import {
   clearSearchIntent,
   useSearchIntent,
 } from "../../customObject/Search/SearchIntentStore.ts";
+import { shortenDisplayName } from "../../customObject/Search/geocode.ts";
 
 export const BASE_NOMINATIM_URL =
   "https://nominatim.openstreetmap.org/search?format=json&limit=5&addressdetails=0&q=";
@@ -40,22 +41,6 @@ type SearchBarRefs = {
   formRef: RefObject<HTMLFormElement | null>;
   listRef: RefObject<HTMLUListElement | null>;
   inputRef: RefObject<HTMLInputElement | null>;
-};
-
-const shortenDisplayName = (value: string): string => {
-  const parts = value
-    .split(",")
-    .map((p) => p.trim())
-    .filter((p) => p.length > 0);
-
-  if (parts.length >= 3 && /^\d+[A-Za-z]?$/.test(parts[0])) {
-    const street = `${parts[0]} ${parts[1]}`;
-    return `${street}, ${parts[2]}`;
-  }
-
-  if (parts.length >= 2) return `${parts[0]}, ${parts[1]}`;
-  if (parts.length === 1) return parts[0];
-  return value;
 };
 
 const deduplicateByName = (items: NominatimResult[]): NominatimResult[] => {

--- a/src/customObject/Search/geocode.test.ts
+++ b/src/customObject/Search/geocode.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { reverseGeocode, shortenDisplayName } from "./geocode";
+
+describe("shortenDisplayName()", () => {
+  it("combine numéro + rue puis ville", () => {
+    expect(shortenDisplayName("12, Rue de la Paix, Paris, France")).toBe("12 Rue de la Paix, Paris");
+  });
+
+  it("garde les deux premières parties sans numéro", () => {
+    expect(shortenDisplayName("Tour Eiffel, Paris, France")).toBe("Tour Eiffel, Paris");
+  });
+
+  it("retourne la valeur seule s'il n'y a qu'une partie", () => {
+    expect(shortenDisplayName("Paris")).toBe("Paris");
+  });
+});
+
+describe("reverseGeocode()", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retourne l'adresse raccourcie en cas de succès", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ display_name: "12, Rue de la Paix, Paris, France" }),
+    }));
+
+    await expect(reverseGeocode(48.86, 2.33)).resolves.toBe("12 Rue de la Paix, Paris");
+  });
+
+  it("inclut lat/lon dans l'URL appelée", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ display_name: "Paris" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await reverseGeocode(48.86, 2.33);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("lat=48.86&lon=2.33"),
+      expect.anything()
+    );
+  });
+
+  it("retourne null si la réponse n'est pas ok", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    await expect(reverseGeocode(0, 0)).resolves.toBeNull();
+  });
+
+  it("retourne null si display_name est absent", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+    await expect(reverseGeocode(0, 0)).resolves.toBeNull();
+  });
+});

--- a/src/customObject/Search/geocode.ts
+++ b/src/customObject/Search/geocode.ts
@@ -1,3 +1,8 @@
+/**
+ * Helpers de géocodage Nominatim partagés entre la barre de recherche
+ * (géocodage direct) et l'ajout de points sur la carte (géocodage inverse).
+ */
+
 export const BASE_NOMINATIM_REVERSE_URL =
   "https://nominatim.openstreetmap.org/reverse?format=json&addressdetails=0";
 

--- a/src/customObject/Search/geocode.ts
+++ b/src/customObject/Search/geocode.ts
@@ -1,0 +1,49 @@
+export const BASE_NOMINATIM_REVERSE_URL =
+  "https://nominatim.openstreetmap.org/reverse?format=json&addressdetails=0";
+
+type NominatimReverseResult = {
+  display_name?: string;
+};
+
+/**
+ * Raccourcit un display_name Nominatim en gardant les parties les plus pertinentes
+ * (numéro + rue, ville) pour un libellé d'étape lisible.
+ * @param value display_name complet renvoyé par Nominatim
+ */
+export const shortenDisplayName = (value: string): string => {
+  const parts = value
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  if (parts.length >= 3 && /^\d+[A-Za-z]?$/.test(parts[0])) {
+    const street = `${parts[0]} ${parts[1]}`;
+    return `${street}, ${parts[2]}`;
+  }
+
+  if (parts.length >= 2) return `${parts[0]}, ${parts[1]}`;
+  if (parts.length === 1) return parts[0];
+  return value;
+};
+
+/**
+ * Géocodage inverse : retourne l'adresse correspondant à des coordonnées,
+ * raccourcie via shortenDisplayName. Retourne null en cas d'échec ou d'absence
+ * de résultat, pour laisser l'appelant conserver un libellé de repli.
+ * @param lat latitude
+ * @param lon longitude
+ * @param signal AbortSignal optionnel
+ */
+export async function reverseGeocode(
+  lat: number,
+  lon: number,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const url = `${BASE_NOMINATIM_REVERSE_URL}&lat=${lat}&lon=${lon}`;
+  const response = await fetch(url, { signal });
+  if (!response.ok) return null;
+
+  const data = (await response.json()) as NominatimReverseResult;
+  const name = data.display_name?.trim();
+  return name ? shortenDisplayName(name) : null;
+}


### PR DESCRIPTION
@
## Contexte
Closes #143

Un clic sur la carte créait une étape titrée avec les coordonnées brutes (`48.860000 2.330000`). On veut récupérer directement ladresse.

## Changements
- Nouveau module partagé `customObject/Search/geocode.ts` :
  - `reverseGeocode(lat, lon, signal?)` → adresse raccourcie via Nominatim `reverse`, `null` en cas déchec.
  - `shortenDisplayName` **déplacé** depuis `useSearchBarLogic` (mutualisé entre recherche directe et inverse, plus de duplication).
- `MapClickHandler` : létape est ajoutée immédiatement avec les coordonnées (retour visuel instantané), puis renommée avec ladresse réelle dès que le géocodage inverse répond. En cas déchec, les coordonnées sont conservées (pas de bruit).

## Notes
- Feature logique sans surface UI dédiée → pas de commit « polish » (3 commits : fonctionnel, docs, tests).
- `renameStep` est un no-op si létape a été supprimée entre-temps : pas de race visible.

## Tests
`geocode.test.ts` : `shortenDisplayName` (3 cas) et `reverseGeocode` (succès, URL lat/lon, réponse non-ok, display_name absent).
@