### PR TITLE
feat: export unifié GPX/PDF et points de passage au PDF (#86 #141 #142)

### DIFF
--- a/src/components/Panels/ActionButtons.test.tsx
+++ b/src/components/Panels/ActionButtons.test.tsx
@@ -26,13 +26,13 @@ vi.mock('../../customObject/Itinerary/ItineraryStore', () => ({
 }));
 
 const downloadGpx = vi.fn();
-const hasGpxGeometry = vi.fn(() => true);
+const hasGpxGeometry = vi.fn((..._args: unknown[]) => true);
 vi.mock('../../customObject/Itinerary/gpx', () => ({
     downloadGpx: (...args: unknown[]) => downloadGpx(...args),
     hasGpxGeometry: (...args: unknown[]) => hasGpxGeometry(...args),
 }));
 
-const downloadItineraryPdf = vi.fn(() => Promise.resolve());
+const downloadItineraryPdf = vi.fn((..._args: unknown[]) => Promise.resolve());
 vi.mock('../../customObject/Itinerary/pdf', () => ({
     downloadItineraryPdf: (...args: unknown[]) => downloadItineraryPdf(...args),
     collectPdfSections: () => [{}],

--- a/src/components/Panels/ActionButtons.test.tsx
+++ b/src/components/Panels/ActionButtons.test.tsx
@@ -25,16 +25,17 @@ vi.mock('../../customObject/Itinerary/ItineraryStore', () => ({
     itineraryModel: { store: {}, netModel: {} },
 }));
 
-const downloadGpx = vi.fn();
-const hasGpxGeometry = vi.fn((..._args: unknown[]) => true);
-vi.mock('../../customObject/Itinerary/gpx', () => ({
-    downloadGpx: (...args: unknown[]) => downloadGpx(...args),
-    hasGpxGeometry: (...args: unknown[]) => hasGpxGeometry(...args),
+const { downloadGpx, hasGpxGeometry, downloadItineraryPdf } = vi.hoisted(() => ({
+    downloadGpx: vi.fn(),
+    hasGpxGeometry: vi.fn(() => true),
+    downloadItineraryPdf: vi.fn(() => Promise.resolve()),
 }));
-
-const downloadItineraryPdf = vi.fn((..._args: unknown[]) => Promise.resolve());
+vi.mock('../../customObject/Itinerary/gpx', () => ({
+    downloadGpx,
+    hasGpxGeometry,
+}));
 vi.mock('../../customObject/Itinerary/pdf', () => ({
-    downloadItineraryPdf: (...args: unknown[]) => downloadItineraryPdf(...args),
+    downloadItineraryPdf,
     collectPdfSections: () => [{}],
 }));
 

--- a/src/components/Panels/ActionButtons.test.tsx
+++ b/src/components/Panels/ActionButtons.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockItinerary = {
+    id: 1,
+    name: 'Convoi test',
+    shareCode: '',
+    segments: [{ id: 'seg-1', content: { geometry: { type: 'Feature' } } }],
+};
+
+vi.mock('../../customObject/Itinerary/UseItinerary', () => ({
+    useItinerary: () => mockItinerary,
+}));
+vi.mock('../../customObject/DeleteMod/useDeleteMod', () => ({
+    useDeleteMod: () => false,
+}));
+vi.mock('../../customObject/SaveState/useIsDirty', () => ({
+    useIsDirty: () => false,
+}));
+vi.mock('../../customObject/DeleteMod/DeleteModStore', () => ({
+    deleteModStore: { set: vi.fn() },
+}));
+vi.mock('../../customObject/Itinerary/ItineraryStore', () => ({
+    itineraryModel: { store: {}, netModel: {} },
+}));
+
+const downloadGpx = vi.fn();
+const hasGpxGeometry = vi.fn(() => true);
+vi.mock('../../customObject/Itinerary/gpx', () => ({
+    downloadGpx: (...args: unknown[]) => downloadGpx(...args),
+    hasGpxGeometry: (...args: unknown[]) => hasGpxGeometry(...args),
+}));
+
+const downloadItineraryPdf = vi.fn(() => Promise.resolve());
+vi.mock('../../customObject/Itinerary/pdf', () => ({
+    downloadItineraryPdf: (...args: unknown[]) => downloadItineraryPdf(...args),
+    collectPdfSections: () => [{}],
+}));
+
+import ActionButtons from './ActionButtons';
+
+describe('ActionButtons export menu', () => {
+    beforeEach(() => {
+        downloadGpx.mockClear();
+        downloadItineraryPdf.mockClear();
+        hasGpxGeometry.mockReturnValue(true);
+    });
+
+    it('ouvre un menu avec les options GPX et PDF', async () => {
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByLabelText("Exporter l'itinéraire"));
+
+        expect(screen.getByText('Télécharger le GPX')).toBeInTheDocument();
+        expect(screen.getByText('Exporter en PDF')).toBeInTheDocument();
+    });
+
+    it('déclenche le téléchargement GPX', async () => {
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByLabelText("Exporter l'itinéraire"));
+        await user.click(screen.getByText('Télécharger le GPX'));
+
+        expect(downloadGpx).toHaveBeenCalledTimes(1);
+    });
+
+    it("déclenche l'export PDF", async () => {
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByLabelText("Exporter l'itinéraire"));
+        await user.click(screen.getByText('Exporter en PDF'));
+
+        expect(downloadItineraryPdf).toHaveBeenCalledTimes(1);
+    });
+
+    it('désactive l\'option GPX sans géométrie', async () => {
+        hasGpxGeometry.mockReturnValue(false);
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByLabelText("Exporter l'itinéraire"));
+
+        expect(screen.getByText('Téléchargement GPX indisponible').closest('button')).toBeDisabled();
+    });
+});

--- a/src/components/Panels/ActionButtons.tsx
+++ b/src/components/Panels/ActionButtons.tsx
@@ -30,6 +30,11 @@ function buildDepartureDateTime(departureDate: string, departureTime: string): D
     return new Date(year, month - 1, day, hours, minutes, 0, 0);
 }
 
+/**
+ * Barre d'actions de l'itinéraire (paramètres, suppression, partage, export, sauvegarde).
+ * L'export GPX et PDF est regroupé derrière un unique bouton « Exporter » qui ouvre
+ * un menu de choix du format.
+ */
 export default function ActionButtons() {
     const delMod = useDeleteMod(deleteModStore);
     const itinerary = useItinerary(itineraryModel.store);

--- a/src/components/Panels/ActionButtons.tsx
+++ b/src/components/Panels/ActionButtons.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Trash, Pencil, Settings, Share2, Download, FileDown } from "lucide-react";
 import "./Panels.css";
+import useOutsideClick from "../useOutsideClick.ts";
 import { deleteModStore } from "../../customObject/DeleteMod/DeleteModStore.ts";
 import { useDeleteMod } from "../../customObject/DeleteMod/useDeleteMod.ts";
 import { itineraryModel } from "../../customObject/Itinerary/ItineraryStore.ts";
@@ -35,6 +36,8 @@ export default function ActionButtons() {
     const isDirty = useIsDirty();
     const [showSettings, setShowSettings] = useState(false);
     const [showShare, setShowShare] = useState(false);
+    const [showExport, setShowExport] = useState(false);
+    const exportRef = useOutsideClick<HTMLDivElement>(() => setShowExport(false));
     const [currentSettings, setCurrentSettings] = useState<GlobalSettings | undefined>(undefined);
     const [isExportingPdf, setIsExportingPdf] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
@@ -55,6 +58,8 @@ export default function ActionButtons() {
     const pdfLabel = isExportingPdf
         ? "G\u00e9n\u00e9ration du PDF..."
         : "Exporter en PDF";
+    const exportLabel = "Exporter l'itin\u00e9raire";
+    const canExport = canDownloadGpx || canExportPdf;
 
     const handleOpenSettings = () => {
         setCurrentSettings(loadGlobalSettings(itinerary));
@@ -103,6 +108,18 @@ export default function ActionButtons() {
         }
     };
 
+    const handleDownloadGpx = () => {
+        setShowExport(false);
+        downloadGpx(itinerary.name, itinerary.segments.map((segment) => ({
+            geometry: segment.content.geometry,
+        })));
+    };
+
+    const handleSelectPdfExport = async () => {
+        setShowExport(false);
+        await handleExportPdf();
+    };
+
     return (
         <>
             <div className={"action-buttons"}>
@@ -134,26 +151,43 @@ export default function ActionButtons() {
                 >
                     <Share2 color={itinerary.shareCode ? "#BB487C" : "#ccc"} />
                 </button>
-                <button
-                    className={"download-gpx-btn"}
-                    aria-label={downloadLabel}
-                    title={downloadLabel}
-                    onClick={() => downloadGpx(itinerary.name, itinerary.segments.map((segment) => ({
-                        geometry: segment.content.geometry,
-                    })))}
-                    disabled={!canDownloadGpx}
-                >
-                    <Download color={canDownloadGpx ? "#BB487C" : "#ccc"} />
-                </button>
-                <button
-                    className={"download-pdf-btn"}
-                    aria-label={pdfLabel}
-                    title={pdfLabel}
-                    onClick={handleExportPdf}
-                    disabled={isExportingPdf || !canExportPdf}
-                >
-                    <FileDown color={isExportingPdf ? "#ccc" : "#BB487C"} />
-                </button>
+                <div className={"export-menu-wrapper"} ref={exportRef}>
+                    <button
+                        className={"export-btn"}
+                        aria-label={exportLabel}
+                        title={exportLabel}
+                        aria-haspopup={"menu"}
+                        aria-expanded={showExport}
+                        onClick={() => setShowExport((prev) => !prev)}
+                        disabled={!canExport || isExportingPdf}
+                    >
+                        <Download color={canExport && !isExportingPdf ? "#BB487C" : "#ccc"} />
+                    </button>
+                    {showExport && (
+                        <div className={"export-menu"} role={"menu"}>
+                            <button
+                                type={"button"}
+                                className={"export-menu-item"}
+                                role={"menuitem"}
+                                onClick={handleDownloadGpx}
+                                disabled={!canDownloadGpx}
+                            >
+                                <Download size={16} />
+                                {downloadLabel}
+                            </button>
+                            <button
+                                type={"button"}
+                                className={"export-menu-item"}
+                                role={"menuitem"}
+                                onClick={handleSelectPdfExport}
+                                disabled={isExportingPdf || !canExportPdf}
+                            >
+                                <FileDown size={16} />
+                                {pdfLabel}
+                            </button>
+                        </div>
+                    )}
+                </div>
             </div>
 
             <div className="save-buttons">

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -474,6 +474,18 @@ h3, .stepTitle {
     box-shadow: 0 12px 28px rgba(95, 23, 58, 0.22);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
+    animation: export-menu-in 120ms ease;
+}
+
+@keyframes export-menu-in {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .action-buttons .export-menu-item {

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -453,6 +453,53 @@ h3, .stepTitle {
     cursor: default;
 }
 
+.export-menu-wrapper {
+    position: relative;
+    display: inline-flex;
+}
+
+.export-menu {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: 0;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    min-width: 220px;
+    padding: 6px;
+    gap: 4px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 2px solid #BB487C;
+    border-radius: 14px;
+    box-shadow: 0 12px 28px rgba(95, 23, 58, 0.22);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.action-buttons .export-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 9px 10px;
+    border-radius: 10px;
+    background: transparent;
+    color: #BB487C;
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(11px, 1.5vw, 13px);
+    font-weight: 600;
+    text-align: left;
+    transition: background 120ms ease;
+}
+
+.action-buttons .export-menu-item:hover:not(:disabled) {
+    background: rgba(187, 72, 124, 0.12);
+}
+
+.action-buttons .export-menu-item:disabled {
+    color: #ccc;
+}
+
 .save-buttons {
     display: flex;
     gap: 6px;

--- a/src/customObject/Itinerary/pdf.test.ts
+++ b/src/customObject/Itinerary/pdf.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Feature, LineString } from "geojson";
 import { TimeSpan } from "../TimeSpan";
-import { collectPdfSections } from "./pdf";
+import { collectPdfSections, splitSectionWaypoints, WAYPOINTS_ON_SECTION_PAGE } from "./pdf";
 import type { Itinerary, Segment } from "./types";
 
 type SegmentOverride = {
@@ -136,5 +136,28 @@ describe("collectPdfSections", () => {
 
         expect(sections).toHaveLength(1);
         expect(sections[0].distanceLabel).toBe("12,5 km");
+    });
+});
+
+describe("splitSectionWaypoints", () => {
+    it("garde tous les points sur la page quand ils tiennent", () => {
+        const titles = ["A", "B", "C"];
+        const { onSection, remaining } = splitSectionWaypoints(titles);
+        expect(onSection).toEqual(["A", "B", "C"]);
+        expect(remaining).toEqual([]);
+    });
+
+    it("limite la page à WAYPOINTS_ON_SECTION_PAGE et numérote le reste", () => {
+        const titles = Array.from({ length: 8 }, (_, index) => `P${index + 1}`);
+        const { onSection, remaining } = splitSectionWaypoints(titles);
+        expect(onSection).toHaveLength(WAYPOINTS_ON_SECTION_PAGE);
+        expect(onSection).toEqual(["P1", "P2", "P3", "P4", "P5"]);
+        expect(remaining).toEqual(["6. P6", "7. P7", "8. P8"]);
+    });
+
+    it("inclut chaque point de passage (page + reste)", () => {
+        const titles = Array.from({ length: 20 }, (_, index) => `Pt${index}`);
+        const { onSection, remaining } = splitSectionWaypoints(titles);
+        expect(onSection.length + remaining.length).toBe(titles.length);
     });
 });

--- a/src/customObject/Itinerary/pdf.ts
+++ b/src/customObject/Itinerary/pdf.ts
@@ -683,6 +683,25 @@ function collectRoutePoints(segment: Segment): RoutePoint[] {
     return geometryPoints.length > 0 ? geometryPoints : stepPoints;
 }
 
+/** Nombre de points de passage listés ligne par ligne sur la page du tronçon. */
+export const WAYPOINTS_ON_SECTION_PAGE = 5;
+
+/**
+ * Répartit les points de passage d'un tronçon entre ceux affichés ligne par ligne
+ * et le reste (résumé en paragraphe), afin que chaque point de passage figure dans le PDF.
+ *
+ * @param stepTitles — Libellés des points de passage du tronçon, dans l'ordre.
+ * @returns `onSection` (lignes détaillées) et `remaining` (numérotés, listés en paragraphe).
+ */
+export function splitSectionWaypoints(stepTitles: string[]): { onSection: string[]; remaining: string[] } {
+    return {
+        onSection: stepTitles.slice(0, WAYPOINTS_ON_SECTION_PAGE),
+        remaining: stepTitles
+            .slice(WAYPOINTS_ON_SECTION_PAGE)
+            .map((title, index) => `${WAYPOINTS_ON_SECTION_PAGE + index + 1}. ${title}`),
+    };
+}
+
 /**
  * Extrait les tronçons exportables d'un itinéraire pour préparer les pages du PDF.
  * Les segments techniques de début et de fin sont ignorés afin de ne garder que
@@ -1055,7 +1074,8 @@ async function buildSectionCanvas(
             maxLines: 4,
         });
     } else {
-        section.stepTitles.slice(0, 5).forEach((stepTitle, stepIndex) => {
+        const { onSection, remaining } = splitSectionWaypoints(section.stepTitles);
+        onSection.forEach((stepTitle, stepIndex) => {
             const rowY = 1442 + stepIndex * 36;
             ctx.save();
             ctx.fillStyle = "rgba(255, 255, 255, 0.96)";
@@ -1076,6 +1096,15 @@ async function buildSectionCanvas(
                 color: "#352B33",
             });
         });
+
+        if (remaining.length > 0) {
+            drawParagraph(ctx, `Autres points de passage : ${remaining.join("  \u2022  ")}`, 118, 1442 + onSection.length * 36 + 8, 1000, 26, {
+                size: 16,
+                weight: 600,
+                color: "#54414C",
+                maxLines: 4,
+            });
+        }
     }
 
     return canvas;


### PR DESCRIPTION
@
## Contexte
Closes #141
Closes #142
Closes #86

Lexport proposait deux boutons séparés (GPX et PDF). On veut un bouton unique qui laisse choisir le format au clic, et un PDF qui inclut chaque point de passage.

## Changements
### Bouton dexport unifié (#141, #86)
- `ActionButtons` : les deux boutons GPX/PDF sont remplacés par un unique bouton « Exporter » qui ouvre un menu déroulant proposant **Télécharger le GPX** et **Exporter en PDF**.
- Chaque option se désactive si indisponible (GPX sans géométrie, PDF en cours / vide). Fermeture au clic extérieur (`useOutsideClick`), `role="menu"`, animation dapparition.

### Points de passage dans le PDF (#142)
- Chaque page de tronçon liste désormais **tous** les points de passage : les 5 premiers en lignes détaillées, le reste numéroté dans un paragraphe « Autres points de passage ».
- Logique extraite dans un helper pur testable `splitSectionWaypoints`.

## Tests
- `pdf.test.ts` : `splitSectionWaypoints` (tout tient / débordement numéroté / exhaustivité).
- `ActionButtons.test.tsx` : ouverture du menu, déclenchement GPX, déclenchement PDF, option GPX désactivée sans géométrie.

## Note
Le rendu canvas du PDF nest pas couvrable en jsdom (pas de canvas) ; la logique testable est isolée dans des helpers purs pour garder la couverture du code neuf au-dessus du seuil.
@