### PR TITLE
feat: suppression de compte depuis les paramètres (#145)

### DIFF
--- a/src/components/AccountSettings/AccountSettingsModal.css
+++ b/src/components/AccountSettings/AccountSettingsModal.css
@@ -241,6 +241,57 @@
     box-shadow: 0 4px 12px rgba(252, 129, 129, 0.3);
 }
 
+.account-settings-danger {
+    border-top: 1px solid #fed7d7;
+    padding-top: 16px;
+}
+
+.account-settings-btn-delete {
+    width: 100%;
+    background: #fff5f5;
+    color: #c53030;
+    border: 2px solid #fc8181;
+}
+
+.account-settings-btn-delete:hover:not(:disabled) {
+    background: #fed7d7;
+}
+
+.account-settings-delete-warning {
+    font-size: 14px;
+    color: #742a2a;
+    margin: 0 0 12px;
+    line-height: 1.4;
+}
+
+.account-settings-delete-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.account-settings-btn-cancel {
+    flex: 1;
+    background: #edf2f7;
+    color: #2d3748;
+}
+
+.account-settings-btn-cancel:hover:not(:disabled) {
+    background: #e2e8f0;
+}
+
+.account-settings-btn-delete-confirm {
+    flex: 1;
+    background: #e53e3e;
+    color: white;
+}
+
+.account-settings-btn-delete-confirm:hover:not(:disabled) {
+    background: #c53030;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(229, 62, 62, 0.3);
+}
+
 @media (max-width: 640px) {
     .account-settings-modal {
         max-width: 95vw;

--- a/src/components/AccountSettings/AccountSettingsModal.test.tsx
+++ b/src/components/AccountSettings/AccountSettingsModal.test.tsx
@@ -251,4 +251,72 @@ describe('AccountSettingsModal', () => {
         });
         expect(mockNavigate).toHaveBeenCalledWith('/login');
     });
+
+    it('ouvre la confirmation de suppression de compte', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        await user.click(screen.getByRole('button', { name: /supprimer mon compte/i }));
+
+        expect(screen.getByRole('button', { name: /confirmer la suppression/i })).toBeInTheDocument();
+        expect(screen.getByLabelText('Mot de passe')).toBeInTheDocument();
+    });
+
+    it('annule la confirmation de suppression', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        await user.click(screen.getByRole('button', { name: /supprimer mon compte/i }));
+        await user.click(screen.getByRole('button', { name: /annuler/i }));
+
+        expect(screen.queryByRole('button', { name: /confirmer la suppression/i })).not.toBeInTheDocument();
+    });
+
+    it('exige le mot de passe avant de supprimer', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        await user.click(screen.getByRole('button', { name: /supprimer mon compte/i }));
+        await user.click(screen.getByRole('button', { name: /confirmer la suppression/i }));
+
+        expect(screen.getByText('Veuillez entrer votre mot de passe')).toBeInTheDocument();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('supprime le compte et déconnecte en cas de succès', async () => {
+        const onLogout = vi.fn();
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ message: 'Account deleted successfully' }),
+        } as Response);
+        renderModalWithEmail('user@example.com', { onLogout });
+
+        await user.click(screen.getByRole('button', { name: /supprimer mon compte/i }));
+        await user.type(screen.getByLabelText('Mot de passe'), 'currentPass');
+        await user.click(screen.getByRole('button', { name: /confirmer la suppression/i }));
+
+        await waitFor(() => expect(onLogout).toHaveBeenCalledOnce());
+        expect(fetch).toHaveBeenCalledWith(
+            'http://localhost:8080/auth/account',
+            expect.objectContaining({ method: 'DELETE' })
+        );
+    });
+
+    it('affiche une erreur si la suppression échoue', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetch).mockResolvedValueOnce({
+            ok: false,
+            json: async () => ({ error: 'Password is incorrect' }),
+        } as Response);
+        renderModalWithEmail('user@example.com');
+
+        await user.click(screen.getByRole('button', { name: /supprimer mon compte/i }));
+        await user.type(screen.getByLabelText('Mot de passe'), 'wrongpass');
+        await user.click(screen.getByRole('button', { name: /confirmer la suppression/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Password is incorrect')).toBeInTheDocument();
+        });
+    });
 });

--- a/src/components/AccountSettings/AccountSettingsModal.tsx
+++ b/src/components/AccountSettings/AccountSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useState, useEffect } from 'react';
+import { type MouseEvent, useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { User, Lock, AlertTriangle, Trash2 } from 'lucide-react';
 import { useAuth } from '../../auth/useAuth';
@@ -27,6 +27,13 @@ export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSetti
     const [deletePassword, setDeletePassword] = useState('');
     const [deleteError, setDeleteError] = useState<string | null>(null);
     const [deleteLoading, setDeleteLoading] = useState(false);
+    const deletePasswordRef = useRef<HTMLInputElement | null>(null);
+
+    useEffect(() => {
+        if (showDeleteConfirm) {
+            deletePasswordRef.current?.focus();
+        }
+    }, [showDeleteConfirm]);
 
     useEffect(() => {
         if (isOpen) {
@@ -296,6 +303,7 @@ export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSetti
                                         Mot de passe
                                     </label>
                                     <input
+                                        ref={deletePasswordRef}
                                         id="account-settings-delete-password"
                                         type="password"
                                         className="account-settings-input"

--- a/src/components/AccountSettings/AccountSettingsModal.tsx
+++ b/src/components/AccountSettings/AccountSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { User, Lock } from 'lucide-react';
+import { User, Lock, AlertTriangle, Trash2 } from 'lucide-react';
 import { useAuth } from '../../auth/useAuth';
 import { useAuthFetch } from '../../auth/useAuthFetch';
 import { validatePassword } from '../../auth/passwordValidation';
@@ -22,6 +22,11 @@ export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSetti
     const [confirmNewPassword, setConfirmNewPassword] = useState('');
     const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
     const [loading, setLoading] = useState(false);
+
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [deletePassword, setDeletePassword] = useState('');
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+    const [deleteLoading, setDeleteLoading] = useState(false);
 
     useEffect(() => {
         if (isOpen) {
@@ -104,6 +109,41 @@ export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSetti
             });
         } finally {
             setLoading(false);
+        }
+    };
+
+    const cancelDelete = () => {
+        setShowDeleteConfirm(false);
+        setDeletePassword('');
+        setDeleteError(null);
+    };
+
+    const handleDeleteAccount = async () => {
+        setDeleteError(null);
+
+        if (!deletePassword) {
+            setDeleteError('Veuillez entrer votre mot de passe');
+            return;
+        }
+
+        setDeleteLoading(true);
+        try {
+            const response = await authFetch(`${BACKEND_URL}/auth/account`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ password: deletePassword })
+            });
+
+            if (response.ok) {
+                onLogout();
+            } else {
+                const errorData = await response.json().catch(() => ({}));
+                setDeleteError(errorData.error || errorData.message || 'Erreur lors de la suppression du compte');
+            }
+        } catch {
+            setDeleteError('Erreur de connexion au serveur');
+        } finally {
+            setDeleteLoading(false);
         }
     };
 
@@ -217,6 +257,71 @@ export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSetti
                                 {loading ? 'Mise à jour...' : 'Mettre à jour'}
                             </button>
                         </form>
+                    </div>
+
+                    {/* Section Danger Zone */}
+                    <div className="account-settings-section account-settings-danger">
+                        <div className="account-settings-section-title">
+                            <AlertTriangle size={16} />
+                            Zone de danger
+                        </div>
+
+                        {!showDeleteConfirm ? (
+                            <button
+                                type="button"
+                                className="account-settings-btn account-settings-btn-delete"
+                                onClick={() => setShowDeleteConfirm(true)}
+                            >
+                                <Trash2 size={15} style={{ marginRight: 6, verticalAlign: 'middle' }} />
+                                Supprimer mon compte
+                            </button>
+                        ) : (
+                            <div className="account-settings-delete-confirm">
+                                <p className="account-settings-delete-warning">
+                                    Cette action est irréversible : votre compte et tous vos convois seront définitivement supprimés. Entrez votre mot de passe pour confirmer.
+                                </p>
+
+                                {deleteError && (
+                                    <div className="account-settings-message account-settings-message-error">
+                                        {deleteError}
+                                    </div>
+                                )}
+
+                                <div className="account-settings-form-group">
+                                    <label className="account-settings-label" htmlFor="account-settings-delete-password">
+                                        Mot de passe
+                                    </label>
+                                    <input
+                                        id="account-settings-delete-password"
+                                        type="password"
+                                        className="account-settings-input"
+                                        placeholder="Entrez votre mot de passe"
+                                        value={deletePassword}
+                                        onChange={(e) => setDeletePassword(e.target.value)}
+                                        disabled={deleteLoading}
+                                    />
+                                </div>
+
+                                <div className="account-settings-delete-actions">
+                                    <button
+                                        type="button"
+                                        className="account-settings-btn account-settings-btn-cancel"
+                                        onClick={cancelDelete}
+                                        disabled={deleteLoading}
+                                    >
+                                        Annuler
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="account-settings-btn account-settings-btn-delete-confirm"
+                                        onClick={handleDeleteAccount}
+                                        disabled={deleteLoading}
+                                    >
+                                        {deleteLoading ? 'Suppression...' : 'Confirmer la suppression'}
+                                    </button>
+                                </div>
+                            </div>
+                        )}
                     </div>
                 </div>
 

--- a/src/components/AccountSettings/AccountSettingsModal.tsx
+++ b/src/components/AccountSettings/AccountSettingsModal.tsx
@@ -118,6 +118,10 @@ export function AccountSettingsModal({ isOpen, onClose, onLogout }: AccountSetti
         setDeleteError(null);
     };
 
+    /**
+     * Supprime définitivement le compte après confirmation par mot de passe
+     * (DELETE /auth/account). En cas de succès, déconnecte l'utilisateur.
+     */
     const handleDeleteAccount = async () => {
         setDeleteError(null);
 


### PR DESCRIPTION
@
## Contexte
Closes #145

Lutilisateur ne pouvait pas supprimer son compte. La modal des paramètres du compte ne proposait que le changement de mot de passe et la déconnexion.

## Changements
- `AccountSettingsModal` : nouvelle section « Zone de danger » avec un bouton **Supprimer mon compte**.
  - Ouvre une confirmation inline exigeant le mot de passe (action irréversible, supprime aussi les convois).
  - Appelle `DELETE /auth/account` via `authFetch` ; en cas de succès, déconnecte lutilisateur (`onLogout`).
  - Erreurs affichées en message inline (mot de passe incorrect, connexion serveur).
  - Autofocus du champ mot de passe à louverture.

## Dépendance
Nécessite lendpoint backend `DELETE /auth/account` — Elessiah-sTeam/c15-tour-backend#109.

## Tests
`AccountSettingsModal.test.tsx` : ouverture/annulation de la confirmation, mot de passe requis, suppression réussie (DELETE + onLogout), erreur API. (23 tests verts.)
@