### PR TITLE
fix: noms d'étape restent les coordonnées GPS au clic carte (#143)

### DIFF
--- a/src/components/Map/MapClickHandler.test.tsx
+++ b/src/components/Map/MapClickHandler.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 type ClickEvent = { latlng: { lat: number; lng: number } };
 let capturedHandlers: { click?: (e: ClickEvent) => void } = {};
@@ -11,27 +11,9 @@ vi.mock('react-leaflet', () => ({
     },
 }));
 
-const addStep = vi.fn();
-const addSegment = vi.fn();
-const renameStep = vi.fn();
-let mockItinerary: { segments: Array<{ id: string; isStartEnd: boolean }> };
-
-vi.mock('../../customObject/Itinerary/ItineraryStore', () => ({
-    itineraryModel: {
-        store: {},
-        addStep: (...args: unknown[]) => addStep(...args),
-        addSegment: (...args: unknown[]) => addSegment(...args),
-        renameStep: (...args: unknown[]) => renameStep(...args),
-    },
-}));
-
-vi.mock('../../customObject/Itinerary/UseItinerary', () => ({
-    useItinerary: () => mockItinerary,
-}));
-
-const reverseGeocode = vi.fn();
-vi.mock('../../customObject/Search/geocode', () => ({
-    reverseGeocode: (...args: unknown[]) => reverseGeocode(...args),
+const addStepFromClick = vi.fn();
+vi.mock('./mapClickUtils', () => ({
+    addStepFromClick: (...args: unknown[]) => addStepFromClick(...args),
 }));
 
 import MapClickHandler from './MapClickHandler';
@@ -39,63 +21,14 @@ import MapClickHandler from './MapClickHandler';
 describe('MapClickHandler', () => {
     beforeEach(() => {
         capturedHandlers = {};
-        addStep.mockClear();
-        addSegment.mockClear();
-        renameStep.mockClear();
-        reverseGeocode.mockReset();
+        addStepFromClick.mockReset();
     });
 
-    it("ajoute une étape avec les coordonnées puis l'adresse géocodée", async () => {
-        mockItinerary = { segments: [{ id: 'seg-1', isStartEnd: false }] };
-        reverseGeocode.mockResolvedValue('12 Rue de la Paix, Paris');
+    it('délègue le clic carte à addStepFromClick avec les coordonnées', () => {
         render(<MapClickHandler />);
 
         capturedHandlers.click!({ latlng: { lat: 48.86, lng: 2.33 } });
 
-        expect(addStep).toHaveBeenCalledWith(
-            'seg-1',
-            expect.objectContaining({
-                content: expect.objectContaining({
-                    title: '48.860000 2.330000',
-                    location: { lat: 48.86, lon: 2.33 },
-                }),
-            })
-        );
-        await waitFor(() =>
-            expect(renameStep).toHaveBeenCalledWith('seg-1', expect.any(String), '12 Rue de la Paix, Paris')
-        );
-    });
-
-    it('crée un segment quand aucun segment régulier', () => {
-        mockItinerary = { segments: [] };
-        reverseGeocode.mockResolvedValue(null);
-        render(<MapClickHandler />);
-
-        capturedHandlers.click!({ latlng: { lat: 1, lng: 2 } });
-
-        expect(addSegment).toHaveBeenCalled();
-        expect(addStep).toHaveBeenCalled();
-    });
-
-    it('conserve les coordonnées quand le géocodage échoue', async () => {
-        mockItinerary = { segments: [{ id: 'seg-1', isStartEnd: false }] };
-        reverseGeocode.mockResolvedValue(null);
-        render(<MapClickHandler />);
-
-        capturedHandlers.click!({ latlng: { lat: 48.86, lng: 2.33 } });
-
-        await waitFor(() => expect(reverseGeocode).toHaveBeenCalled());
-        expect(renameStep).not.toHaveBeenCalled();
-    });
-
-    it('ignore une erreur réseau du géocodage sans planter', async () => {
-        mockItinerary = { segments: [{ id: 'seg-1', isStartEnd: false }] };
-        reverseGeocode.mockRejectedValue(new Error('network'));
-        render(<MapClickHandler />);
-
-        capturedHandlers.click!({ latlng: { lat: 48.86, lng: 2.33 } });
-
-        await waitFor(() => expect(reverseGeocode).toHaveBeenCalled());
-        expect(renameStep).not.toHaveBeenCalled();
+        expect(addStepFromClick).toHaveBeenCalledWith(48.86, 2.33);
     });
 });

--- a/src/components/Map/MapClickHandler.tsx
+++ b/src/components/Map/MapClickHandler.tsx
@@ -1,68 +1,14 @@
 import { useMapEvents } from "react-leaflet";
-import { itineraryModel } from "../../customObject/Itinerary/ItineraryStore.ts";
-import { useItinerary } from "../../customObject/Itinerary/UseItinerary.ts";
-import type { Segment } from "../../customObject/Itinerary/types.ts";
-import { TimeSpan } from "../../customObject/TimeSpan.ts";
-import { reverseGeocode } from "../../customObject/Search/geocode.ts";
+import { addStepFromClick } from "./mapClickUtils.ts";
 
 /**
- * Gère les clics sur la carte pour créer une nouvelle étape
- * L'étape est ajoutée au dernier segment, qui est créé si nécessaire.
- * Le libellé affiche d'abord les coordonnées puis est remplacé par l'adresse
- * réelle obtenue par géocodage inverse (les coordonnées restent en cas d'échec).
+ * Gère les clics sur la carte pour créer une nouvelle étape avec son adresse réelle.
  */
 export default function MapClickHandler() {
-    const itinerary = useItinerary(itineraryModel.store);
-
     useMapEvents({
         click(e) {
             const { lat, lng } = e.latlng;
-            const title = `${lat.toFixed(6)} ${lng.toFixed(6)}`;
-
-            const regularSegments = itinerary.segments.filter(
-                (seg: Segment) => !seg.isStartEnd
-            );
-
-            let targetSegmentId: string;
-
-            if (regularSegments.length > 0) {
-                targetSegmentId = regularSegments[regularSegments.length - 1].id;
-            } else {
-                const newSegment: Segment = {
-                    id: "newseg" + new Date().toISOString(),
-                    content: {
-                        title: "Nouveau segment",
-                        hour: new Date(),
-                        duration: new TimeSpan(),
-                        distance: 0,
-                    },
-                    isStartEnd: false,
-                    steps: [],
-                };
-                itineraryModel.addSegment(newSegment);
-                targetSegmentId = newSegment.id;
-            }
-
-            const stepId = "mapclick" + new Date().toISOString();
-            itineraryModel.addStep(targetSegmentId, {
-                id: stepId,
-                content: {
-                    title,
-                    duration: new TimeSpan(),
-                    location: { lat, lon: lng },
-                },
-                isDefaultSegStart: false,
-            });
-
-            reverseGeocode(lat, lng)
-                .then((address) => {
-                    if (address) {
-                        itineraryModel.renameStep(targetSegmentId, stepId, address);
-                    }
-                })
-                .catch(() => {
-                    // Géocodage indisponible : on conserve les coordonnées comme libellé.
-                });
+            void addStepFromClick(lat, lng);
         },
     });
 

--- a/src/components/Map/mapClickUtils.test.ts
+++ b/src/components/Map/mapClickUtils.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Itinerary } from "../../customObject/Itinerary/types";
+
+const h = vi.hoisted(() => ({
+    addStep: vi.fn(),
+    addSegment: vi.fn(),
+    reverseGeocode: vi.fn(),
+    route: { segments: [] as Itinerary["segments"] } as Itinerary,
+}));
+
+vi.mock("../../customObject/Search/geocode.ts", () => ({
+    reverseGeocode: h.reverseGeocode,
+}));
+
+vi.mock("../../customObject/Itinerary/ItineraryStore.ts", () => ({
+    itineraryModel: {
+        get route() {
+            return h.route;
+        },
+        addStep: h.addStep,
+        addSegment: h.addSegment,
+    },
+}));
+
+import { addStepFromClick } from "./mapClickUtils";
+
+function segment(id: string, isStartEnd = false) {
+    return { id, isStartEnd, steps: [], content: {} } as unknown as Itinerary["segments"][number];
+}
+
+function lastAddedTitle(): string {
+    const lastCall = h.addStep.mock.calls.at(-1);
+    return lastCall?.[1].content.title;
+}
+
+describe("addStepFromClick()", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        h.route = { segments: [segment("s1")] } as Itinerary;
+    });
+
+    it("utilise l'adresse géocodée comme titre", async () => {
+        h.reverseGeocode.mockResolvedValue("Rue de Test, Paris");
+        await addStepFromClick(47.1, 2.2);
+        expect(h.addStep).toHaveBeenCalledWith("s1", expect.anything());
+        expect(lastAddedTitle()).toBe("Rue de Test, Paris");
+    });
+
+    it("retombe sur les coordonnées si le géocodage renvoie null", async () => {
+        h.reverseGeocode.mockResolvedValue(null);
+        await addStepFromClick(47, 2);
+        expect(lastAddedTitle()).toBe("47.000000 2.000000");
+    });
+
+    it("retombe sur les coordonnées si le géocodage échoue", async () => {
+        h.reverseGeocode.mockRejectedValue(new Error("network"));
+        await addStepFromClick(47, 2);
+        expect(lastAddedTitle()).toBe("47.000000 2.000000");
+    });
+
+    it("enregistre la localisation du clic sur l'étape", async () => {
+        h.reverseGeocode.mockResolvedValue("Lieu");
+        await addStepFromClick(48.5, -1.5);
+        expect(h.addStep.mock.calls.at(-1)?.[1].content.location).toEqual({ lat: 48.5, lon: -1.5 });
+    });
+
+    it("crée un segment quand il n'existe que le départ/arrivée", async () => {
+        h.route = { segments: [segment("start", true), segment("end", true)] } as Itinerary;
+        h.reverseGeocode.mockResolvedValue("Lieu");
+        await addStepFromClick(47, 2);
+        expect(h.addSegment).toHaveBeenCalledTimes(1);
+        expect(h.addStep).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/Map/mapClickUtils.ts
+++ b/src/components/Map/mapClickUtils.ts
@@ -1,0 +1,64 @@
+import { itineraryModel } from "../../customObject/Itinerary/ItineraryStore.ts";
+import type { Segment } from "../../customObject/Itinerary/types.ts";
+import { TimeSpan } from "../../customObject/TimeSpan.ts";
+import { reverseGeocode } from "../../customObject/Search/geocode.ts";
+
+/**
+ * Ajoute une étape au dernier segment (créé si nécessaire) à partir d'un clic carte.
+ *
+ * L'adresse réelle est résolue par géocodage inverse AVANT l'ajout : la sauvegarde
+ * backend déclenchée par addStep réassigne des ids numériques aux étapes, donc un
+ * renommage différé viserait un id devenu obsolète et serait sans effet. Résoudre
+ * le libellé en amont garantit qu'il est persisté. Repli sur les coordonnées si
+ * le géocodage échoue.
+ *
+ * @param lat latitude du clic
+ * @param lon longitude du clic
+ */
+export async function addStepFromClick(lat: number, lon: number): Promise<void> {
+    const fallbackTitle = `${lat.toFixed(6)} ${lon.toFixed(6)}`;
+    let title = fallbackTitle;
+
+    try {
+        const address = await reverseGeocode(lat, lon);
+        if (address) {
+            title = address;
+        }
+    } catch {
+        // Géocodage indisponible : on conserve les coordonnées comme libellé.
+    }
+
+    const regularSegments = itineraryModel.route.segments.filter(
+        (seg: Segment) => !seg.isStartEnd
+    );
+
+    let targetSegmentId: string;
+
+    if (regularSegments.length > 0) {
+        targetSegmentId = regularSegments[regularSegments.length - 1].id;
+    } else {
+        const newSegment: Segment = {
+            id: "newseg" + new Date().toISOString(),
+            content: {
+                title: "Nouveau segment",
+                hour: new Date(),
+                duration: new TimeSpan(),
+                distance: 0,
+            },
+            isStartEnd: false,
+            steps: [],
+        };
+        itineraryModel.addSegment(newSegment);
+        targetSegmentId = newSegment.id;
+    }
+
+    itineraryModel.addStep(targetSegmentId, {
+        id: "mapclick" + new Date().toISOString(),
+        content: {
+            title,
+            duration: new TimeSpan(),
+            location: { lat, lon },
+        },
+        isDefaultSegStart: false,
+    });
+}

--- a/src/components/Map/mapClickUtils.ts
+++ b/src/components/Map/mapClickUtils.ts
@@ -35,7 +35,7 @@ export async function addStepFromClick(lat: number, lon: number): Promise<void> 
     let targetSegmentId: string;
 
     if (regularSegments.length > 0) {
-        targetSegmentId = regularSegments[regularSegments.length - 1].id;
+        targetSegmentId = regularSegments.at(-1)!.id;
     } else {
         const newSegment: Segment = {
             id: "newseg" + new Date().toISOString(),


### PR DESCRIPTION
@
## Contexte
Suivi de #143. En pratique, les étapes créées au clic carte gardaient les coordonnées GPS comme nom, malgré le géocodage inverse.

## Cause
`addStep` déclenche une sauvegarde backend (`setupSave` → `put`). La réponse appliquée (`applyItinerary` → `normalizeSegments`/`normalizeWaypoints`) **réassigne des ids numériques** à tous les segments/étapes. Le renommage différé (`reverseGeocode().then(renameStep(...))`) ciblait alors lid dorigine (`"mapclick…"`) qui nexiste plus → no-op → le nom restait les coordonnées.

(La recherche ne souffrait pas du bug car elle ajoute létape avec le titre adresse dès le départ.)

## Correctif
- Le géocodage inverse est résolu **avant** lajout : létape est créée directement avec le bon libellé, qui survit donc à la réassignation dids. Repli sur les coordonnées si le géocodage échoue/rien.
- Logique extraite dans `mapClickUtils.ts` (testable, hors composant) ; `MapClickHandler` ne fait plus que router le clic.

## Tests
`mapClickUtils.test.ts` : titre = adresse géocodée, repli coordonnées (null et exception), localisation enregistrée, création de segment si seulement départ/arrivée.
@