### PR TITLE
fix: marqueurs des points de passage sur la carte du PDF (#142)

### DIFF
--- a/src/customObject/Itinerary/pdf.test.ts
+++ b/src/customObject/Itinerary/pdf.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Feature, LineString } from "geojson";
 import { TimeSpan } from "../TimeSpan";
-import { collectPdfSections, splitSectionWaypoints, WAYPOINTS_ON_SECTION_PAGE } from "./pdf";
+import { collectPdfSections, downloadItineraryPdf, splitSectionWaypoints, WAYPOINTS_ON_SECTION_PAGE } from "./pdf";
 import type { Itinerary, Segment } from "./types";
+
+// Les tuiles OSM déclenchent des requêtes réseau : on force le repli vectoriel (drawn: false).
+vi.mock("./pdfMapTiles.ts", () => ({
+    drawOsmTilesAndProjector: vi.fn(async () => ({ drawn: false })),
+}));
 
 type SegmentOverride = {
     id?: string;
@@ -184,5 +189,68 @@ describe("splitSectionWaypoints", () => {
         const titles = Array.from({ length: 20 }, (_, index) => `Pt${index}`);
         const { onSection, remaining } = splitSectionWaypoints(titles);
         expect(onSection.length + remaining.length).toBe(titles.length);
+    });
+});
+
+describe("downloadItineraryPdf", () => {
+    // jsdom n'implémente pas le canvas : on simule un contexte 2D qui absorbe tous les appels de dessin.
+    function createMockContext(): CanvasRenderingContext2D {
+        const gradient = { addColorStop: vi.fn() };
+        return new Proxy(
+            {},
+            {
+                get(_target, prop) {
+                    if (prop === "measureText") {
+                        return () => ({ width: 100 });
+                    }
+                    if (prop === "createLinearGradient") {
+                        return () => gradient;
+                    }
+                    return () => undefined;
+                },
+                set: () => true,
+            },
+        ) as unknown as CanvasRenderingContext2D;
+    }
+
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+
+    beforeEach(() => {
+        vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+            createMockContext() as unknown as RenderingContext,
+        );
+        vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/jpeg;base64,AAAA");
+        vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => undefined);
+        URL.createObjectURL = vi.fn(() => "blob:mock");
+        URL.revokeObjectURL = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        URL.createObjectURL = originalCreateObjectURL;
+        URL.revokeObjectURL = originalRevokeObjectURL;
+    });
+
+    function buildWaypointItinerary(): Itinerary {
+        return buildItinerary([
+            buildSegment({ id: "start", isStartEnd: true, content: { title: " ", geometry: undefined } }),
+            buildSegment({
+                id: "leg",
+                content: { title: "Tronçon", geometry: undefined },
+                steps: [
+                    { id: "a", isDefaultSegStart: false, content: { title: "Départ", duration: new TimeSpan(), location: { lat: 47, lon: -1 } } },
+                    { id: "m", isDefaultSegStart: false, content: { title: "Halte", duration: new TimeSpan(), location: { lat: 47.5, lon: -1.5 } } },
+                    { id: "b", isDefaultSegStart: false, content: { title: "Arrivée", duration: new TimeSpan(), location: { lat: 48, lon: -2 } } },
+                ],
+            }),
+            buildSegment({ id: "end", isStartEnd: true, content: { title: " ", geometry: undefined } }),
+        ]);
+    }
+
+    it("génère le PDF en matérialisant les points de passage sur les cartes", async () => {
+        await expect(downloadItineraryPdf(buildWaypointItinerary())).resolves.toBeUndefined();
+        expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);
+        expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/customObject/Itinerary/pdf.test.ts
+++ b/src/customObject/Itinerary/pdf.test.ts
@@ -112,6 +112,31 @@ describe("collectPdfSections", () => {
         ]);
     });
 
+    it("collects geolocated waypoints with their labels", () => {
+        const itinerary = buildItinerary([
+            buildSegment({ id: "start", isStartEnd: true, content: { title: " ", geometry: undefined } }),
+            buildSegment({
+                id: "leg-wp",
+                content: { title: "Tronçon", geometry: undefined },
+                steps: [
+                    { id: "a", isDefaultSegStart: false, content: { title: "Départ", duration: new TimeSpan(), location: { lat: 47, lon: -1 } } },
+                    { id: "m", isDefaultSegStart: false, content: { title: "Halte", duration: new TimeSpan(), location: { lat: 47.5, lon: -1.5 } } },
+                    { id: "n", isDefaultSegStart: false, content: { title: "Sans coord", duration: new TimeSpan() } },
+                    { id: "b", isDefaultSegStart: false, content: { title: "Arrivée", duration: new TimeSpan(), location: { lat: 48, lon: -2 } } },
+                ],
+            }),
+            buildSegment({ id: "end", isStartEnd: true, content: { title: " ", geometry: undefined } }),
+        ]);
+
+        const sections = collectPdfSections(itinerary);
+
+        expect(sections[0].waypoints).toEqual([
+            { lat: 47, lon: -1, label: "Départ" },
+            { lat: 47.5, lon: -1.5, label: "Halte" },
+            { lat: 48, lon: -2, label: "Arrivée" },
+        ]);
+    });
+
     it("formats segment distances with a French decimal comma", () => {
         const itinerary = buildItinerary([
             buildSegment({ id: "start", isStartEnd: true, content: { title: " ", geometry: undefined } }),

--- a/src/customObject/Itinerary/pdf.ts
+++ b/src/customObject/Itinerary/pdf.ts
@@ -32,6 +32,7 @@ type ExportSection = {
     departureLabel: string;
     stepTitles: string[];
     routePoints: RoutePoint[];
+    waypoints: RoutePoint[];
 };
 
 type PdfBinary = Uint8Array;
@@ -433,7 +434,12 @@ async function drawRouteSnapshot(
     height: number,
     routes: RoutePoint[][],
     title: string,
-    options: { variant: "section" | "overview"; showOverlayLabel?: boolean },
+    options: {
+        variant: "section" | "overview";
+        showOverlayLabel?: boolean;
+        waypoints?: RoutePoint[];
+        numberWaypoints?: boolean;
+    },
 ): Promise<void> {
     const routesWithPath = routes.filter((route) => route.length >= 2);
     const legendHeight = routesWithPath.length > 0 ? 88 : 0;
@@ -557,24 +563,54 @@ async function drawRouteSnapshot(
         ctx.restore();
     };
 
-    const showIntermediate =
-        options.variant === "section" && routesWithPath.length === 1 && routesWithPath[0].length >= 3;
-
-    if (showIntermediate) {
-        const decimated = decimateRoutePoints(routesWithPath[0], PDF_ROUTE_MAX_VERTICES);
-        decimated.forEach((routePoint, index) => {
-            if (index === 0 || index === decimated.length - 1 || !routePoint.label) {
-                return;
-            }
-            const point = projectPoint(routePoint);
+    const drawWaypointMarker = (point: { x: number; y: number }, label: string, numbered: boolean): void => {
+        if (!numbered) {
             ctx.save();
             ctx.fillStyle = EXPORT_ACCENT;
+            ctx.strokeStyle = "#FFFFFF";
+            ctx.lineWidth = 2;
             ctx.beginPath();
-            ctx.arc(point.x, point.y, 7, 0, Math.PI * 2);
+            ctx.arc(point.x, point.y, 8, 0, Math.PI * 2);
             ctx.fill();
+            ctx.stroke();
             ctx.restore();
+            return;
+        }
+
+        ctx.save();
+        ctx.shadowColor = "rgba(93, 17, 62, 0.24)";
+        ctx.shadowBlur = 10;
+        ctx.shadowOffsetY = 3;
+        ctx.fillStyle = EXPORT_ACCENT;
+        ctx.beginPath();
+        ctx.arc(point.x, point.y, 13, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+
+        ctx.save();
+        ctx.strokeStyle = "#FFFFFF";
+        ctx.lineWidth = 2.5;
+        ctx.beginPath();
+        ctx.arc(point.x, point.y, 13, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
+
+        drawText(ctx, label, point.x, point.y + 1, {
+            size: 15,
+            weight: 900,
+            color: "#FFFFFF",
+            align: "center",
+            baseline: "middle",
         });
-    }
+    };
+
+    const waypoints = options.waypoints ?? [];
+    waypoints.forEach((waypoint, index) => {
+        if (!Number.isFinite(waypoint.lat) || !Number.isFinite(waypoint.lon)) {
+            return;
+        }
+        drawWaypointMarker(projectPoint(waypoint), `${index + 1}`, options.numberWaypoints === true);
+    });
 
     drawMarker(firstMapped, "#16A34A");
     drawMarker(lastMapped, "#E11D48");
@@ -683,6 +719,24 @@ function collectRoutePoints(segment: Segment): RoutePoint[] {
     return geometryPoints.length > 0 ? geometryPoints : stepPoints;
 }
 
+/**
+ * Extrait les points de passage d'un segment (étapes géolocalisées) avec leur libellé,
+ * dans l'ordre, pour les matérialiser par des marqueurs sur la carte du PDF.
+ *
+ * @param segment — Segment métier.
+ * @returns Points de passage avec coordonnées finies et libellé.
+ */
+function collectSegmentWaypoints(segment: Segment): RoutePoint[] {
+    return segment.steps
+        .filter((step) => step.content.location)
+        .map((step) => ({
+            lat: step.content.location!.lat,
+            lon: step.content.location!.lon,
+            label: step.content.title.trim(),
+        }))
+        .filter((point) => Number.isFinite(point.lat) && Number.isFinite(point.lon));
+}
+
 /** Nombre de points de passage listés ligne par ligne sur la page du tronçon. */
 export const WAYPOINTS_ON_SECTION_PAGE = 5;
 
@@ -728,6 +782,7 @@ export function collectPdfSections(itinerary: Itinerary): ExportSection[] {
                 departureLabel: formatDateTime(segment.content.hour),
                 stepTitles,
                 routePoints: collectRoutePoints(segment),
+                waypoints: collectSegmentWaypoints(segment),
             };
         });
 }
@@ -812,9 +867,12 @@ async function buildCoverCanvas(itinerary: Itinerary, sections: ExportSection[])
     });
 
     drawShadowedPanel(ctx, 84, 402, 1072, 700, 34, EXPORT_PANEL);
+    const coverWaypoints = sections.flatMap((section) => section.waypoints.slice(1, -1));
     await drawRouteSnapshot(ctx, 108, 438, 1024, 628, overviewRoutesForCover(itinerary, sections), title, {
         variant: "overview",
         showOverlayLabel: false,
+        waypoints: coverWaypoints,
+        numberWaypoints: false,
     });
 
     drawShadowedPanel(ctx, 84, 1118, 1072, 170, 30, EXPORT_PANEL);
@@ -1016,6 +1074,8 @@ async function buildSectionCanvas(
     await drawRouteSnapshot(ctx, 120, 396, 1000, 710, [section.routePoints], section.title, {
         variant: "section",
         showOverlayLabel: false,
+        waypoints: section.waypoints.slice(1, -1),
+        numberWaypoints: true,
     });
 
     drawShadowedPanel(ctx, 84, 1178, 1072, 450, 32, "rgba(255, 255, 255, 0.92)");

--- a/src/customObject/Itinerary/pdf.ts
+++ b/src/customObject/Itinerary/pdf.ts
@@ -598,7 +598,7 @@ async function drawRouteSnapshot(
         ctx.restore();
 
         drawText(ctx, label, point.x, point.y + 1, {
-            size: 15,
+            size: label.length >= 2 ? 12 : 15,
             weight: 900,
             color: "#FFFFFF",
             align: "center",

--- a/src/customObject/Itinerary/pdf.ts
+++ b/src/customObject/Itinerary/pdf.ts
@@ -423,7 +423,9 @@ function drawFallbackGrid(ctx: CanvasRenderingContext2D, x: number, y: number, w
  * @param height — Hauteur du bloc.
  * @param routes — Une ou plusieurs polylignes (vue d'ensemble = un tableau par tronçon). Les tracés de moins de 2 points sont ignorés.
  * @param title — Sous-titre affiché dans l'étiquette (ex. nom du convoi ou du tronçon).
- * @param options.variant — `"overview"` : pas de pastilles intermédiaires ; `"section"` : pastilles sur les étapes pour un seul tronçon.
+ * @param options.variant — `"overview"` (carte d'ensemble) ou `"section"` (carte d'un tronçon).
+ * @param options.waypoints — Points de passage intermédiaires à matérialiser sur la carte (hors départ/arrivée).
+ * @param options.numberWaypoints — `true` : pastilles numérotées (1, 2, …) ; `false` : simples points (vue d'ensemble).
  * @remarks Effectue des requêtes réseau lorsque les tuiles OSM sont utilisées. Restaure le contexte (`ctx.restore`) après tracé.
  */
 async function drawRouteSnapshot(


### PR DESCRIPTION
@
## Contexte
Suivi de #142. Les points de passage napparaissaient pas comme marqueurs sur la carte du PDF (seule une liste texte existait). Demande : des marqueurs sur la carte.

## Changements
- `drawRouteSnapshot` dessine désormais les points de passage :
  - **Pages de tronçon** : pastilles **numérotées** (1, 2, …) pour chaque point de passage intermédiaire, en plus du départ (vert) / arrivée (rouge).
  - **Page de couverture** : points visibles (non numérotés) pour rester lisible sur la vue densemble.
- Nouveau helper `collectSegmentWaypoints` ; champ `waypoints` ajouté à `ExportSection` (étapes géolocalisées avec libellé).
- Remplace lancien rendu de points intermédiaires (qui naffichait rien quand la géométrie était présente, car seuls départ/arrivée portaient un label).
- La liste texte « Étapes et arrêts » (#152) est conservée.

## Notes
- Le rendu canvas du PDF nest pas couvrable par les tests (cf. politique de couverture). Les tests portent sur la couche données.

## Tests
`pdf.test.ts` : nouvelle assertion sur `collectPdfSections(...).waypoints` (extraction des étapes géolocalisées + libellés, exclusion des étapes sans coordonnées).
@