### PR TITLE
fix: géocodage via proxy /nominatim (CORS/403 OSM) (#143)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,4 +6,15 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
+
+    # Proxy de géocodage Nominatim : évite le blocage CORS/403 du navigateur en
+    # appelant l'API côté serveur avec un User-Agent identifiant l'application,
+    # comme l'exige la politique d'usage d'OpenStreetMap.
+    location /nominatim/ {
+        proxy_pass https://nominatim.openstreetmap.org/;
+        proxy_ssl_server_name on;
+        proxy_set_header Host nominatim.openstreetmap.org;
+        proxy_set_header User-Agent "c15-tour/1.0 (+https://github.com/Elessiah-sTeam/c15-tour-webapp)";
+        proxy_set_header Referer "https://github.com/Elessiah-sTeam/c15-tour-webapp";
+    }
 }

--- a/src/components/Search/useSearchBarLogic.ts
+++ b/src/components/Search/useSearchBarLogic.ts
@@ -14,8 +14,10 @@ import {
 } from "../../customObject/Search/SearchIntentStore.ts";
 import { shortenDisplayName } from "../../customObject/Search/geocode.ts";
 
+// Passe par le proxy nginx / Vite (/nominatim) : appel direct à OSM bloqué côté
+// navigateur (CORS/403). Le proxy ajoute un User-Agent identifiant l'application.
 export const BASE_NOMINATIM_URL =
-  "https://nominatim.openstreetmap.org/search?format=json&limit=5&addressdetails=0&q=";
+  "/nominatim/search?format=json&limit=5&addressdetails=0&q=";
 
 export type NominatimResult = {
   lat: string;

--- a/src/customObject/Search/geocode.ts
+++ b/src/customObject/Search/geocode.ts
@@ -3,8 +3,10 @@
  * (géocodage direct) et l'ajout de points sur la carte (géocodage inverse).
  */
 
+// Passe par le proxy nginx / Vite (/nominatim) plutôt que d'appeler OSM en direct :
+// le navigateur est sinon bloqué (CORS/403) faute de User-Agent identifiant l'app.
 export const BASE_NOMINATIM_REVERSE_URL =
-  "https://nominatim.openstreetmap.org/reverse?format=json&addressdetails=0";
+  "/nominatim/reverse?format=json&addressdetails=0";
 
 type NominatimReverseResult = {
   display_name?: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,20 @@ export default defineConfig({
       },
     }),
   ],
+  // En dev (npm run dev), proxifie /nominatim vers OSM avec un User-Agent identifiant
+  // l'app, comme le fait nginx en production : évite le blocage CORS/403 du navigateur.
+  server: {
+    proxy: {
+      '/nominatim': {
+        target: 'https://nominatim.openstreetmap.org',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/nominatim/, ''),
+        headers: {
+          'User-Agent': 'c15-tour/1.0 (+https://github.com/Elessiah-sTeam/c15-tour-webapp)',
+        },
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Problème
Le géocodage inverse (noms d'étape au clic carte, #143) et la recherche d'adresse échouaient en build local : Nominatim/OSM renvoie **403 Forbidden** aux appels directs du navigateur (politique d'usage : User-Agent navigateur non identifiant + reverse en rafale), que le navigateur affiche en **erreur CORS** (`No 'Access-Control-Allow-Origin' header`).

## Correctif
Proxy same-origin `/nominatim` qui appelle OSM côté serveur avec un User-Agent identifiant l'application (conforme à la politique OSM) :
- **Prod** : `nginx.conf` → `location /nominatim/ { proxy_pass https://nominatim.openstreetmap.org/; ... }`
- **Dev** (`npm run dev`) : `vite.config.ts` → `server.proxy['/nominatim']`
- `geocode.ts` (reverse) et `useSearchBarLogic.ts` (search) pointent désormais sur `/nominatim/...`

Vérifié : avec un User-Agent conforme, Nominatim répond **200** + `Access-Control-Allow-Origin: *`.

> ⚠️ Le correctif n'est effectif qu'après reconstruction de l'image frontend (`docker compose up -d --build`), le proxy étant dans la conf nginx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)