### PR TITLE
test: couverture unitaire + E2E Playwright du cahier de test (webapp)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,38 @@ jobs:
       - name: Build
         run: npm run build
 
+  e2e:
+    name: Tests E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Tests E2E
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ Thumbs.db
 # Optional: testing
 coverage/
 
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 #IA
 .claude/
 /.claude/

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+import { seedAuth, stubExternalMaps, json, buildToursPage } from './helpers';
+
+/**
+ * Cahier de test — Module Authentification (AUTH-01..08).
+ */
+test.describe('Authentification', () => {
+  test('AUTH-08 — accès sans connexion redirige vers /login', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole('heading', { name: 'Connexion' })).toBeVisible();
+  });
+
+  test('AUTH-02 — connexion avec compte valide accède à l’accueil', async ({ page }) => {
+    await page.route('**/auth/login', (route) =>
+      route.fulfill(json({ token: 'jwt-valide' })),
+    );
+
+    await page.goto('/login');
+    await page.getByLabel('Adresse email').fill('pilote@c15.fr');
+    await page.getByLabel('Mot de passe').fill('motdepasse');
+    await page.getByRole('button', { name: 'Se connecter' }).click();
+
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText(/Bienvenue sur l'outil C15/i)).toBeVisible();
+  });
+
+  test('AUTH-03 — mauvais mot de passe affiche une erreur', async ({ page }) => {
+    await page.route('**/auth/login', (route) => route.fulfill({ status: 401 }));
+
+    await page.goto('/login');
+    await page.getByLabel('Adresse email').fill('pilote@c15.fr');
+    await page.getByLabel('Mot de passe').fill('mauvais');
+    await page.getByRole('button', { name: 'Se connecter' }).click();
+
+    await expect(page.getByText('Identifiants incorrects. Veuillez réessayer.')).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+
+  test('AUTH-04 — email inconnu affiche une erreur', async ({ page }) => {
+    await page.route('**/auth/login', (route) => route.fulfill({ status: 401 }));
+
+    await page.goto('/login');
+    await page.getByLabel('Adresse email').fill('inconnu@c15.fr');
+    await page.getByLabel('Mot de passe').fill('peu importe');
+    await page.getByRole('button', { name: 'Se connecter' }).click();
+
+    await expect(page.getByText('Identifiants incorrects. Veuillez réessayer.')).toBeVisible();
+  });
+
+  test('AUTH-05 — champs vides : la validation empêche la soumission', async ({ page }) => {
+    let loginCalled = false;
+    await page.route('**/auth/login', (route) => {
+      loginCalled = true;
+      return route.fulfill(json({ token: 'x' }));
+    });
+
+    await page.goto('/login');
+    await page.getByRole('button', { name: 'Se connecter' }).click();
+
+    await expect(page).toHaveURL(/\/login$/);
+    expect(loginCalled).toBe(false);
+    // Le champ email natif est invalide (required).
+    const emailValid = await page.getByLabel('Adresse email').evaluate(
+      (el: HTMLInputElement) => el.checkValidity(),
+    );
+    expect(emailValid).toBe(false);
+  });
+
+  test('AUTH-06 — lien « Mot de passe oublié » ouvre le parcours de réinitialisation', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByRole('link', { name: 'Mot de passe oublié ?' }).click();
+    await expect(page).toHaveURL(/\/forgot-password$/);
+  });
+
+  test('AUTH-01 — créer un compte puis être redirigé vers la connexion', async ({ page }) => {
+    await page.route('**/auth/register', (route) =>
+      route.fulfill({ status: 201, contentType: 'application/json', body: '{}' }),
+    );
+
+    await page.goto('/register');
+    await page.getByLabel('Adresse email').fill('nouveau@c15.fr');
+    await page.getByLabel('Mot de passe', { exact: true }).fill('Motdepasse1!');
+    await page.getByLabel('Confirmer le mot de passe').fill('Motdepasse1!');
+    await page.getByRole('button', { name: 'Créer mon compte' }).click();
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByText(/Compte créé avec succès/i)).toBeVisible();
+  });
+
+  test('AUTH-07 — déconnexion ramène à la page de connexion', async ({ page }) => {
+    await seedAuth(page);
+    await stubExternalMaps(page);
+    await page.route(/\/tours(\?|$)/, (route) => route.fulfill(json(buildToursPage([]))));
+
+    await page.goto('/history');
+    await page.getByRole('button', { name: 'Se déconnecter' }).click();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -20,7 +20,8 @@ export async function seedAuth(page: Page, email = 'pilote@c15.fr'): Promise<voi
 /** Bloque les tuiles de carte et les requêtes Nominatim (réseau externe). */
 export async function stubExternalMaps(page: Page): Promise<void> {
   await page.route(/tile\.openstreetmap\.org/, (route: Route) => route.abort());
-  await page.route(/nominatim\.openstreetmap\.org.*/, (route: Route) =>
+  // Le géocodage passe soit en direct (OSM), soit par le proxy applicatif (/nominatim).
+  await page.route(/(nominatim\.openstreetmap\.org|\/nominatim\/)/, (route: Route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
   );
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,61 @@
+import type { Page, Route } from '@playwright/test';
+
+/**
+ * Helpers partagés pour les tests E2E.
+ * Le backend (localhost:8080) et les ressources cartographiques externes
+ * sont interceptés pour rendre les tests déterministes et hors-ligne.
+ */
+
+/** Pré-charge un jeton d'authentification afin de simuler un utilisateur connecté. */
+export async function seedAuth(page: Page, email = 'pilote@c15.fr'): Promise<void> {
+  await page.addInitScript(
+    ([token, mail]) => {
+      localStorage.setItem('auth_token', token);
+      localStorage.setItem('auth_email', mail);
+    },
+    ['e2e-token', email],
+  );
+}
+
+/** Bloque les tuiles de carte et les requêtes Nominatim (réseau externe). */
+export async function stubExternalMaps(page: Page): Promise<void> {
+  await page.route(/tile\.openstreetmap\.org/, (route: Route) => route.abort());
+  await page.route(/nominatim\.openstreetmap\.org.*/, (route: Route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+}
+
+/** Réponse JSON pratique. */
+export function json(body: unknown, status = 200) {
+  return { status, contentType: 'application/json', body: JSON.stringify(body) };
+}
+
+/** Construit un convoi minimal conforme à TourResponse. */
+export function buildTour(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    name: 'Convoi Démo',
+    shareCode: 'DEMO01',
+    totalDistance: 50000,
+    totalDuration: 3600,
+    draft: false,
+    segments: [
+      {
+        name: 'Étape 1',
+        distance: 50000,
+        duration: 3600,
+        geometry: JSON.stringify({ type: 'LineString', coordinates: [[2.1, 48.1], [2.2, 48.2]] }),
+        waypoints: [
+          { name: 'Paris', coordinates: { latitude: 48.85, longitude: 2.35 } },
+          { name: 'Versailles', coordinates: { latitude: 48.8, longitude: 2.13 } },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/** Page de listing /tours paginée. */
+export function buildToursPage(content: unknown[]) {
+  return { content, totalPages: content.length > 0 ? 1 : 0, totalElements: content.length };
+}

--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { seedAuth, stubExternalMaps, json, buildTour, buildToursPage } from './helpers';
+
+// Patterns mutuellement exclusifs : la liste (/tours ou /tours?...) vs le détail (/tours/<id>).
+const TOURS_LIST = /\/tours(\?|$)/;
+const TOUR_DETAIL = /\/tours\/1$/;
+
+/**
+ * Cahier de test — Module Historique (HIST-01..08).
+ */
+test.describe('Historique des convois', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAuth(page);
+    await stubExternalMaps(page);
+  });
+
+  test('HIST-02 — aucun convoi affiche le message vide', async ({ page }) => {
+    await page.route(TOURS_LIST, (route) => route.fulfill(json(buildToursPage([]))));
+
+    await page.goto('/history');
+    await expect(page.getByText(/Aucun convoi trouvé/i)).toBeVisible();
+  });
+
+  test('HIST-01 — liste uniquement les convois renvoyés par le backend', async ({ page }) => {
+    await page.route(TOURS_LIST, (route) =>
+      route.fulfill(
+        json(
+          buildToursPage([
+            buildTour({ id: 1, name: 'Tour de Bretagne', draft: false }),
+            buildTour({ id: 2, name: 'Virée des Alpes', draft: true }),
+          ]),
+        ),
+      ),
+    );
+
+    await page.goto('/history');
+    await expect(page.getByRole('heading', { name: 'Tour de Bretagne' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Virée des Alpes' })).toBeVisible();
+  });
+
+  test('HIST-07 — la recherche filtre la liste par nom', async ({ page }) => {
+    await page.route(TOURS_LIST, (route) =>
+      route.fulfill(
+        json(
+          buildToursPage([
+            buildTour({ id: 1, name: 'Tour de Bretagne' }),
+            buildTour({ id: 2, name: 'Virée des Alpes' }),
+          ]),
+        ),
+      ),
+    );
+
+    await page.goto('/history');
+    await page.getByPlaceholder(/Rechercher un convoi/i).fill('Bretagne');
+
+    await expect(page.getByRole('heading', { name: 'Tour de Bretagne' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Virée des Alpes' })).toHaveCount(0);
+  });
+
+  test('HIST-08 — le filtre Finalisés ne garde que les convois finalisés', async ({ page }) => {
+    await page.route(TOURS_LIST, (route) =>
+      route.fulfill(
+        json(
+          buildToursPage([
+            buildTour({ id: 1, name: 'Tour Finalise', draft: false }),
+            buildTour({ id: 2, name: 'Tour Brouillon', draft: true }),
+          ]),
+        ),
+      ),
+    );
+
+    await page.goto('/history');
+    await page.getByRole('button', { name: 'Finalisés' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Tour Finalise' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Tour Brouillon' })).toHaveCount(0);
+  });
+
+  test('HIST-03 — ouvrir un convoi mène à la carte', async ({ page }) => {
+    await page.route(TOUR_DETAIL, (route) => route.fulfill(json(buildTour({ id: 1 }))));
+    await page.route(TOURS_LIST, (route) =>
+      route.fulfill(json(buildToursPage([buildTour({ id: 1, name: 'Convoi à ouvrir' })]))),
+    );
+
+    await page.goto('/history');
+    await page.getByRole('button', { name: /Ouvrir/ }).click();
+    await expect(page).toHaveURL(/\/planner\?id=1/);
+  });
+});

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { seedAuth, stubExternalMaps, json, buildToursPage } from './helpers';
+
+/**
+ * Cahier de test — Module Accueil (ACC-01..04).
+ */
+test.describe('Page d’accueil', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAuth(page);
+    await stubExternalMaps(page);
+    await page.route(/\/tours(\?|$)/, (route) => route.fulfill(json(buildToursPage([]))));
+  });
+
+  test('ACC-01 — affiche les deux actions principales (ACC-04 design C15)', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText(/C15 Fiesta Tour/i).first()).toBeVisible();
+    await expect(page.getByText('Créer un nouveau convoi')).toBeVisible();
+    await expect(page.getByText(/Accéder à l'historique des convois/i)).toBeVisible();
+  });
+
+  test('ACC-02 — créer un nouveau convoi redirige vers la carte (/planner)', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('Créer un nouveau convoi').click();
+    await expect(page).toHaveURL(/\/planner/);
+  });
+
+  test('ACC-03 — accéder à l’historique redirige vers la liste', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText(/Accéder à l'historique des convois/i).click();
+    await expect(page).toHaveURL(/\/history$/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.61.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -121,6 +122,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -493,6 +495,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -541,6 +544,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -562,6 +566,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1331,6 +1336,22 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@react-leaflet/core": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
@@ -1768,8 +1789,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1871,6 +1891,7 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1881,6 +1902,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1891,6 +1913,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1941,6 +1964,7 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -2192,6 +2216,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -2336,6 +2361,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2376,7 +2402,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2511,6 +2536,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2721,8 +2747,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.263",
@@ -2822,6 +2847,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3470,7 +3496,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3534,7 +3561,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3787,11 +3813,59 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -3839,7 +3913,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3855,7 +3928,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3887,6 +3959,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3896,6 +3969,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3908,8 +3982,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -4300,6 +4373,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4396,6 +4470,7 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4471,6 +4546,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -4689,6 +4765,7 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -26,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.61.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Tests E2E (UI) du cahier de test C15 Tour — partie webapp.
+ * Le serveur applicatif est démarré automatiquement (build + preview Vite).
+ * Aucune dépendance réseau réelle : le backend et les tuiles de carte sont
+ * interceptés au niveau de la page (voir e2e/helpers.ts).
+ */
+const PORT = 4173;
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `npm run build && npm run preview -- --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/src/components/History/ItineraryCard.test.tsx
+++ b/src/components/History/ItineraryCard.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ItineraryCard } from "./ItineraryCard";
+import type { ItineraryResponse } from "../../customObject/Itinerary/netTypes";
+
+// ConvoyThumbnail rend un canvas/leaflet-like ; on le neutralise pour isoler la carte.
+vi.mock("./ConvoyThumbnail", () => ({
+    ConvoyThumbnail: () => <div data-testid="thumb" />,
+}));
+
+const geometry = JSON.stringify({ type: "LineString", coordinates: [[2.1, 48.1], [2.2, 48.2]] });
+
+function buildItinerary(overrides: Partial<ItineraryResponse> = {}): ItineraryResponse {
+    return {
+        id: 7,
+        name: "Convoi Bretagne",
+        shareCode: "SHARE7",
+        totalDistance: 120000,
+        totalDuration: 7200,
+        draft: false,
+        segments: [
+            { name: "S1", distance: 120000, duration: 7200, geometry, waypoints: [
+                { name: "Rennes", coordinates: { latitude: 48.1, longitude: -1.6 } },
+                { name: "Brest", coordinates: { latitude: 48.4, longitude: -4.5 } },
+            ] },
+        ],
+        ...overrides,
+    };
+}
+
+function setup(overrides: Partial<ItineraryResponse> = {}, props: Partial<Parameters<typeof ItineraryCard>[0]> = {}) {
+    const handlers = {
+        onOpen: vi.fn(),
+        onDelete: vi.fn(),
+        onShare: vi.fn(),
+        onExportPdf: vi.fn(),
+    };
+    render(<ItineraryCard itinerary={buildItinerary(overrides)} {...handlers} {...props} />);
+    return handlers;
+}
+
+describe("ItineraryCard", () => {
+    beforeEach(() => vi.restoreAllMocks());
+
+    it("affiche le nom, le trajet et les statistiques (HIST-01)", () => {
+        setup();
+        expect(screen.getByText("Convoi Bretagne")).toBeInTheDocument();
+        expect(screen.getByText(/Rennes/)).toBeInTheDocument();
+        expect(screen.getByText(/Brest/)).toBeInTheDocument();
+        expect(screen.getByText("2 points")).toBeInTheDocument();
+        expect(screen.getByText("120 km")).toBeInTheDocument();
+        expect(screen.getByText("2h00")).toBeInTheDocument();
+    });
+
+    it("affiche le badge Finalisé ou Brouillon (HIST-08)", () => {
+        setup({ draft: false });
+        expect(screen.getByText("Finalisé")).toBeInTheDocument();
+    });
+
+    it("affiche le badge Brouillon pour un convoi en brouillon (HIST-08)", () => {
+        setup({ draft: true });
+        expect(screen.getByText("Brouillon")).toBeInTheDocument();
+    });
+
+    it("ouvre le convoi au clic sur Ouvrir (HIST-03)", async () => {
+        const user = userEvent.setup();
+        const { onOpen } = setup();
+        await user.click(screen.getByRole("button", { name: /Ouvrir/ }));
+        expect(onOpen).toHaveBeenCalledWith(7);
+    });
+
+    it("supprime le convoi au clic sur la corbeille (HIST-04)", async () => {
+        const user = userEvent.setup();
+        const { onDelete } = setup();
+        await user.click(screen.getByRole("button", { name: /supprimer/i }));
+        expect(onDelete).toHaveBeenCalledWith(7);
+    });
+
+    it("partage le convoi avec son shareCode (SHARE)", async () => {
+        const user = userEvent.setup();
+        const { onShare } = setup();
+        await user.click(screen.getByRole("button", { name: /^partager$/i }));
+        expect(onShare).toHaveBeenCalledWith("SHARE7");
+    });
+
+    it("désactive le partage sans shareCode", () => {
+        setup({ shareCode: undefined });
+        expect(screen.getByRole("button", { name: /partage indisponible/i })).toBeDisabled();
+    });
+
+    it("exporte en PDF (EXP-01)", async () => {
+        const user = userEvent.setup();
+        const { onExportPdf } = setup();
+        await user.click(screen.getByRole("button", { name: /exporter en pdf/i }));
+        expect(onExportPdf).toHaveBeenCalledWith(7);
+    });
+
+    it("désactive l'export PDF pendant la génération", () => {
+        setup({}, { isExportingPdf: true });
+        expect(screen.getByRole("button", { name: /génération du pdf/i })).toBeDisabled();
+    });
+
+    it("désactive le GPX quand aucune géométrie n'est disponible (EXP-03)", () => {
+        setup({ segments: [{ name: "S", distance: 0, duration: 0, geometry: "", waypoints: [] }] });
+        expect(screen.getByRole("button", { name: /indisponible/i })).toBeInTheDocument();
+    });
+});

--- a/src/components/Home/HomeLanding.test.tsx
+++ b/src/components/Home/HomeLanding.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import HomeLanding from "./HomeLanding";
+
+// Couvre ACC-01 (affichage accueil), ACC-02 (créer un convoi),
+// ACC-03 (accéder historique) et ACC-04 (design cohérent C15 Tour).
+describe("HomeLanding", () => {
+    it("affiche le titre de marque C15 (ACC-04)", () => {
+        render(<HomeLanding />);
+        // Texte exact pour cibler le bandeau de marque (et non le message de bienvenue).
+        expect(screen.getByText("C15 Fiesta Tour")).toBeInTheDocument();
+    });
+
+    it("affiche les deux actions principales (ACC-01)", () => {
+        render(<HomeLanding />);
+        expect(screen.getByText("Créer un nouveau convoi")).toBeInTheDocument();
+        expect(screen.getByText(/Accéder à l'historique des convois/i)).toBeInTheDocument();
+    });
+
+    it("déclenche onCreateNew au clic sur « Créer un nouveau convoi » (ACC-02)", async () => {
+        const onCreateNew = vi.fn();
+        const user = userEvent.setup();
+        render(<HomeLanding onCreateNew={onCreateNew} />);
+
+        await user.click(screen.getByText("Créer un nouveau convoi"));
+        expect(onCreateNew).toHaveBeenCalledOnce();
+    });
+
+    it("déclenche onOpenHistory au clic sur l'historique (ACC-03)", async () => {
+        const onOpenHistory = vi.fn();
+        const user = userEvent.setup();
+        render(<HomeLanding onOpenHistory={onOpenHistory} />);
+
+        await user.click(screen.getByText(/Accéder à l'historique des convois/i));
+        expect(onOpenHistory).toHaveBeenCalledOnce();
+    });
+
+    it("ouvre les paramètres du compte", async () => {
+        const onOpenAccountSettings = vi.fn();
+        const user = userEvent.setup();
+        render(<HomeLanding onOpenAccountSettings={onOpenAccountSettings} />);
+
+        await user.click(screen.getByRole("button", { name: /paramètres du compte/i }));
+        expect(onOpenAccountSettings).toHaveBeenCalledOnce();
+    });
+});

--- a/src/components/Panels/ShareModal.test.tsx
+++ b/src/components/Panels/ShareModal.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ShareModal from "./ShareModal";
+
+// Couvre SHARE-01 (code participant), SHARE-03 (QR code) et SHARE-04 (copier le code).
+describe("ShareModal", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("affiche le code de partage", () => {
+        render(<ShareModal shareCode="ABC123" onClose={() => {}} />);
+        expect(screen.getByText("ABC123")).toBeInTheDocument();
+        expect(screen.getByText("Partager le convoi")).toBeInTheDocument();
+    });
+
+    it("affiche un QR code (SVG) contenant le code", () => {
+        render(<ShareModal shareCode="QR-CODE-42" onClose={() => {}} />);
+        // La modale est rendue dans un portail (document.body) ; qrcode.react rend un <svg>.
+        expect(document.body.querySelector(".share-qr-container svg")).toBeInTheDocument();
+    });
+
+    it("copie le code dans le presse-papier au clic", async () => {
+        // userEvent.setup() fournit un presse-papier simulé que l'on relit ensuite.
+        const user = userEvent.setup();
+
+        render(<ShareModal shareCode="COPY-ME" onClose={() => {}} />);
+        await user.click(screen.getByRole("button", { name: /copier le code/i }));
+
+        expect(await navigator.clipboard.readText()).toBe("COPY-ME");
+        // Le bouton reste accessible après la confirmation visuelle (icône Check).
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: /copier le code/i })).toBeInTheDocument();
+        });
+    });
+
+    it("ferme la modale via le bouton fermer", async () => {
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        render(<ShareModal shareCode="X" onClose={onClose} />);
+
+        await user.click(screen.getAllByRole("button", { name: /fermer/i })[0]);
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it("ferme la modale avec la touche Échap", async () => {
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        render(<ShareModal shareCode="X" onClose={onClose} />);
+
+        await user.keyboard("{Escape}");
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/src/components/Search/useSearchBarLogic.test.ts
+++ b/src/components/Search/useSearchBarLogic.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createRef } from "react";
+import { useSearchBarLogic } from "./useSearchBarLogic";
+
+// react-leaflet useMap requiert un contexte de carte ; on le neutralise.
+const flyTo = vi.fn();
+vi.mock("react-leaflet", () => ({ useMap: () => ({ flyTo }) }));
+
+function makeRefs() {
+    return {
+        formRef: createRef<HTMLFormElement>(),
+        listRef: createRef<HTMLUListElement>(),
+        inputRef: createRef<HTMLInputElement>(),
+    };
+}
+
+function renderSearch() {
+    const onLocationSelected = vi.fn();
+    const refs = makeRefs();
+    const view = renderHook(() => useSearchBarLogic({ onLocationSelected, refs }));
+    return { ...view, onLocationSelected };
+}
+
+// Déclenche le debounce (250ms) puis laisse résoudre le fetch.
+async function runDebouncedSearch(handleChange: (v: string) => void, value: string) {
+    act(() => handleChange(value));
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+    });
+}
+
+// Couvre WEB-02 (recherche d'adresse), WEB-04 (recherche sans résultat).
+describe("useSearchBarLogic", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        flyTo.mockReset();
+    });
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it("renvoie les résultats de recherche d'adresse (WEB-02)", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => [{ lat: "48.85", lon: "2.35", display_name: "Paris, France" }],
+        }));
+
+        const { result } = renderSearch();
+        await runDebouncedSearch(result.current.handlers.handleChange, "Paris");
+
+        expect(result.current.state.results).toHaveLength(1);
+        expect(result.current.state.results[0].display_name).toBe("Paris, France");
+        expect(result.current.state.error).toBeNull();
+    });
+
+    it("affiche « Lieu introuvable » sans résultat (WEB-04)", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => [] }));
+
+        const { result } = renderSearch();
+        await runDebouncedSearch(result.current.handlers.handleChange, "zzzzzzz");
+
+        expect(result.current.state.error).toBe("Lieu introuvable");
+        expect(result.current.state.results).toHaveLength(0);
+    });
+
+    it("dédoublonne les résultats par nom", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => [
+                { lat: "1", lon: "1", display_name: "Lyon" },
+                { lat: "1", lon: "1", display_name: "Lyon" },
+                { lat: "2", lon: "2", display_name: "Nantes" },
+            ],
+        }));
+
+        const { result } = renderSearch();
+        await runDebouncedSearch(result.current.handlers.handleChange, "ville");
+
+        expect(result.current.state.results).toHaveLength(2);
+    });
+
+    it("vide les résultats quand la requête est effacée", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => [{ lat: "1", lon: "1", display_name: "Lyon" }],
+        }));
+
+        const { result } = renderSearch();
+        await runDebouncedSearch(result.current.handlers.handleChange, "Lyon");
+        expect(result.current.state.results).toHaveLength(1);
+
+        act(() => result.current.handlers.handleChange(""));
+        expect(result.current.state.results).toHaveLength(0);
+    });
+});

--- a/src/components/SettingsModal/SettingsModal.test.tsx
+++ b/src/components/SettingsModal/SettingsModal.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingsModal } from "./SettingsModal";
+import type { GlobalSettings } from "./settingsTypes";
+
+const baseSettings: GlobalSettings = {
+    convoyName: "Convoi initial",
+    departureDate: "2026-06-17",
+    departureTime: "08:00",
+    speedPercentage: 100,
+    minSegmentDuration: 1,
+    maxSegmentDuration: 4,
+    pauseConfigs: [],
+};
+
+// Couvre PARAM-01..06 : ouverture, modification vitesse / durée max, validation, annulation.
+describe("SettingsModal", () => {
+    it("ne rend rien quand elle est fermée (PARAM-01)", () => {
+        const { container } = render(
+            <SettingsModal isOpen={false} onClose={() => {}} onSave={() => {}} />
+        );
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("affiche le panneau de paramètres globaux quand ouverte (PARAM-01)", () => {
+        render(<SettingsModal isOpen onClose={() => {}} onSave={() => {}} initialSettings={baseSettings} />);
+        expect(screen.getByText("Paramètres globaux")).toBeInTheDocument();
+        expect(screen.getByLabelText("Nom du convoi")).toHaveValue("Convoi initial");
+    });
+
+    it("modifie le pourcentage de vitesse moyenne (PARAM-02)", async () => {
+        const onSave = vi.fn();
+        const user = userEvent.setup();
+        render(<SettingsModal isOpen onClose={() => {}} onSave={onSave} initialSettings={baseSettings} />);
+
+        const slider = screen.getByRole("slider");
+        fireEvent.change(slider, { target: { value: "80" } });
+        expect(screen.getByText(/limites de vitesse : 80%/i)).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /enregistrer/i }));
+        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ speedPercentage: 80 }));
+    });
+
+    it("modifie la durée maximale d'un segment (PARAM-03)", async () => {
+        const onSave = vi.fn();
+        const user = userEvent.setup();
+        render(<SettingsModal isOpen onClose={() => {}} onSave={onSave} initialSettings={baseSettings} />);
+
+        const maxDuration = screen.getByLabelText("Durée maximale (heures)");
+        await user.clear(maxDuration);
+        await user.type(maxDuration, "6");
+        await user.click(screen.getByRole("button", { name: /enregistrer/i }));
+
+        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ maxSegmentDuration: 6 }));
+    });
+
+    it("valide et applique les paramètres puis ferme (PARAM-05)", async () => {
+        const onSave = vi.fn();
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        render(<SettingsModal isOpen onClose={onClose} onSave={onSave} initialSettings={baseSettings} />);
+
+        const nameInput = screen.getByLabelText("Nom du convoi");
+        await user.clear(nameInput);
+        await user.type(nameInput, "Tour2026");
+        await user.click(screen.getByRole("button", { name: /enregistrer/i }));
+
+        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ convoyName: "Tour2026" }));
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it("annule sans sauvegarder, conserve les anciennes valeurs (PARAM-06)", async () => {
+        const onSave = vi.fn();
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        render(<SettingsModal isOpen onClose={onClose} onSave={onSave} initialSettings={baseSettings} />);
+
+        await user.clear(screen.getByLabelText("Nom du convoi"));
+        await user.type(screen.getByLabelText("Nom du convoi"), "Jeté");
+        await user.click(screen.getByRole("button", { name: /annuler/i }));
+
+        expect(onSave).not.toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it("indique l'absence de pauses tant qu'aucune n'est définie", () => {
+        render(<SettingsModal isOpen onClose={() => {}} onSave={() => {}} initialSettings={baseSettings} />);
+        expect(screen.getByText(/pauses apparaîtront ici/i)).toBeInTheDocument();
+    });
+});

--- a/src/customObject/Itinerary/fileName.test.ts
+++ b/src/customObject/Itinerary/fileName.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeFileName } from "./fileName";
+
+// Couvre EXP-01/EXP-03 : nommage des fichiers exportés (PDF / GPX).
+describe("sanitizeFileName()", () => {
+    it("conserve un nom simple", () => {
+        expect(sanitizeFileName("Mon convoi")).toBe("Mon-convoi");
+    });
+
+    it("remplace les caractères interdits par le système de fichiers", () => {
+        expect(sanitizeFileName('Tour:<>"/\\|?*2026')).toBe("Tour-2026");
+    });
+
+    it("supprime les accents", () => {
+        expect(sanitizeFileName("Été à Nîmes")).toBe("Ete-a-Nimes");
+    });
+
+    it("normalise les espaces multiples en un seul tiret", () => {
+        expect(sanitizeFileName("A    B   C")).toBe("A-B-C");
+    });
+
+    it("retire les tirets en début et fin", () => {
+        expect(sanitizeFileName("  convoi  ")).toBe("convoi");
+    });
+
+    it("retourne 'itinerary' quand le nom est vide", () => {
+        expect(sanitizeFileName("")).toBe("itinerary");
+        expect(sanitizeFileName("***")).toBe("itinerary");
+    });
+});

--- a/src/customObject/Itinerary/gpxDownload.test.ts
+++ b/src/customObject/Itinerary/gpxDownload.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { downloadGpx } from "./gpx";
+
+// Couvre EXP-03 : déclenchement du téléchargement GPX.
+describe("downloadGpx()", () => {
+    const segment = {
+        geometry: { type: "LineString", coordinates: [[2.1, 48.1], [2.2, 48.2]] as [number, number][] },
+    };
+
+    beforeEach(() => {
+        vi.stubGlobal("URL", {
+            createObjectURL: vi.fn(() => "blob:fake-url"),
+            revokeObjectURL: vi.fn(),
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it("crée un lien de téléchargement avec l'extension .gpx et clique dessus", () => {
+        const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+        downloadGpx("Mon convoi", [segment]);
+
+        expect(window.URL.createObjectURL).toHaveBeenCalledOnce();
+        expect(clickSpy).toHaveBeenCalledOnce();
+        expect(window.URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake-url");
+    });
+
+    it("nettoie le DOM après le téléchargement", () => {
+        vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+        downloadGpx("Convoi", [segment]);
+
+        expect(document.querySelector("a[download]")).toBeNull();
+    });
+
+    it("lève une erreur quand aucune géométrie n'est exploitable", () => {
+        expect(() => downloadGpx("Vide", [{ geometry: undefined }])).toThrow();
+    });
+});

--- a/src/customObject/SaveState/SaveStateStore.test.ts
+++ b/src/customObject/SaveState/SaveStateStore.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { saveStateStore } from "./SaveStateStore";
+
+// Couvre SAVE-03 : suivi de l'état "modifications non sauvegardées" (dirty).
+describe("saveStateStore", () => {
+    afterEach(() => {
+        saveStateStore.set(() => false);
+    });
+
+    it("démarre dans un état propre (non dirty)", () => {
+        expect(saveStateStore.getSnapshot()).toBe(false);
+    });
+
+    it("passe à dirty via set()", () => {
+        saveStateStore.set(() => true);
+        expect(saveStateStore.getSnapshot()).toBe(true);
+    });
+
+    it("expose la valeur précédente à l'updater", () => {
+        saveStateStore.set(() => true);
+        saveStateStore.set((prev) => !prev);
+        expect(saveStateStore.getSnapshot()).toBe(false);
+    });
+
+    it("notifie les abonnés à chaque changement", () => {
+        const listener = vi.fn();
+        const unsubscribe = saveStateStore.subscribe(listener);
+
+        saveStateStore.set(() => true);
+        saveStateStore.set(() => false);
+
+        expect(listener).toHaveBeenCalledTimes(2);
+        unsubscribe();
+    });
+
+    it("n'appelle plus un abonné après désinscription", () => {
+        const listener = vi.fn();
+        const unsubscribe = saveStateStore.subscribe(listener);
+        unsubscribe();
+
+        saveStateStore.set(() => true);
+
+        expect(listener).not.toHaveBeenCalled();
+    });
+});

--- a/src/customObject/Toast/ToastStore.test.ts
+++ b/src/customObject/Toast/ToastStore.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { toastStore, pushErrorToast, pushInfoToast, pushSuccessToast } from "./ToastStore";
+
+// Couvre UX-03 : remontée des messages d'erreur / d'information à l'utilisateur.
+describe("toastStore", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        // Vide les toasts résiduels d'autres tests.
+        toastStore.getSnapshot().forEach((t) => toastStore.dismiss(t.id));
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+    it("ajoute un toast avec le bon niveau et message", () => {
+        pushErrorToast("Une erreur est survenue");
+        const toasts = toastStore.getSnapshot();
+        expect(toasts).toHaveLength(1);
+        expect(toasts[0]).toMatchObject({ level: "error", message: "Une erreur est survenue" });
+    });
+
+    it("gère les trois niveaux de toast", () => {
+        pushErrorToast("err");
+        pushInfoToast("info");
+        pushSuccessToast("ok");
+        expect(toastStore.getSnapshot().map((t) => t.level)).toEqual(["error", "info", "success"]);
+    });
+
+    it("attribue des identifiants uniques", () => {
+        const id1 = pushInfoToast("a");
+        const id2 = pushInfoToast("b");
+        expect(id1).not.toBe(id2);
+    });
+
+    it("retire un toast via dismiss()", () => {
+        const id = pushInfoToast("à fermer");
+        toastStore.dismiss(id);
+        expect(toastStore.getSnapshot()).toHaveLength(0);
+    });
+
+    it("retire automatiquement le toast après 5 secondes", () => {
+        pushInfoToast("auto");
+        expect(toastStore.getSnapshot()).toHaveLength(1);
+        vi.advanceTimersByTime(5000);
+        expect(toastStore.getSnapshot()).toHaveLength(0);
+    });
+
+    it("notifie les abonnés lors d'un ajout", () => {
+        const listener = vi.fn();
+        const unsubscribe = toastStore.subscribe(listener);
+        pushInfoToast("x");
+        expect(listener).toHaveBeenCalled();
+        unsubscribe();
+    });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
+    // Les tests unitaires Vitest vivent dans src/ ; les specs Playwright (e2e/) sont exclues.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],


### PR DESCRIPTION
## Objectif

Couvrir la plus grande partie possible du **cahier de test C15 Tour** côté **webapp** (la partie mobile est hors périmètre), et ajouter des tests UI E2E avec Playwright intégrés à la CI.

## Tests unitaires ajoutés (Vitest)

| Domaine | Cas du cahier | Fichier |
|---|---|---|
| Export | EXP-01/03 | `fileName.test.ts`, `gpxDownload.test.ts` |
| UX | UX-03 | `ToastStore.test.ts` |
| Sauvegarde | SAVE-03 | `SaveStateStore.test.ts` |
| Partage | SHARE-01/03/04 | `ShareModal.test.tsx` |
| Paramètres | PARAM-01..06 | `SettingsModal.test.tsx` |
| Accueil | ACC-01..04 | `HomeLanding.test.tsx` |
| Historique | HIST-01/03/04/08 | `ItineraryCard.test.tsx` |
| Web/Recherche | WEB-02/04 | `useSearchBarLogic.test.ts` |

Total : **334 tests unitaires** verts (41 fichiers).

## Tests E2E (Playwright)

Nouveau dossier `e2e/`. Le backend (`localhost:8080`), les tuiles OSM et Nominatim sont interceptés, ce qui rend les tests déterministes et hors-ligne.

- `auth.spec.ts` — AUTH-01 à AUTH-08
- `home.spec.ts` — ACC-01..04
- `history.spec.ts` — HIST-01/02/03/07/08

Total : **16 tests E2E** verts.

## CI

- Nouveau job `e2e` : `playwright install --with-deps chromium` puis `npm run test:e2e`, avec upload du rapport HTML en artifact.
- `vitest.include` limité à `src/**` pour que Vitest n'exécute pas les specs Playwright.
- Scripts `test:e2e` / `test:e2e:ui` ajoutés.

## Hors périmètre

Modules Mobile (MOB), Audio (AUDIO) et Notifications (NOTIF) : ils relèvent de l'app mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
