### PR TITLE
feat(share): partager le code orga en plus du code membre

### DIFF
--- a/src/components/History/HistoryPage.css
+++ b/src/components/History/HistoryPage.css
@@ -340,6 +340,53 @@ html, body {
     border-color: #BB487C;
 }
 
+.ch-share-wrapper {
+    position: relative;
+    display: inline-flex;
+}
+
+.ch-share-menu {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: 0;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    min-width: 170px;
+    padding: 6px;
+    gap: 4px;
+    background: #ffffff;
+    border: 2px solid #BB487C;
+    border-radius: 12px;
+    box-shadow: 0 12px 28px rgba(95, 23, 58, 0.22);
+}
+
+.ch-share-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 9px 10px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: #BB487C;
+    font-size: 13px;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+    transition: background 120ms ease;
+}
+
+.ch-share-menu-item:hover:not(:disabled) {
+    background: rgba(187, 72, 124, 0.12);
+}
+
+.ch-share-menu-item:disabled {
+    color: #ccc;
+    cursor: default;
+}
+
 .ch-empty {
     text-align: center;
     padding: 60px 20px;

--- a/src/components/History/ItineraryCard.test.tsx
+++ b/src/components/History/ItineraryCard.test.tsx
@@ -77,15 +77,31 @@ describe("ItineraryCard", () => {
         expect(onDelete).toHaveBeenCalledWith(7);
     });
 
-    it("partage le convoi avec son shareCode (SHARE)", async () => {
+    it("partage le code membre via le menu de partage (SHARE)", async () => {
         const user = userEvent.setup();
-        const { onShare } = setup();
+        const { onShare } = setup({ organiserCode: "ORGA7" });
         await user.click(screen.getByRole("button", { name: /^partager$/i }));
-        expect(onShare).toHaveBeenCalledWith("SHARE7");
+        await user.click(screen.getByRole("menuitem", { name: /code membre/i }));
+        expect(onShare).toHaveBeenCalledWith("SHARE7", "Code membre");
     });
 
-    it("désactive le partage sans shareCode", () => {
-        setup({ shareCode: undefined });
+    it("partage le code orga via le menu de partage (SHARE)", async () => {
+        const user = userEvent.setup();
+        const { onShare } = setup({ organiserCode: "ORGA7" });
+        await user.click(screen.getByRole("button", { name: /^partager$/i }));
+        await user.click(screen.getByRole("menuitem", { name: /code orga/i }));
+        expect(onShare).toHaveBeenCalledWith("ORGA7", "Code orga");
+    });
+
+    it("désactive le choix code orga quand il est absent", async () => {
+        const user = userEvent.setup();
+        setup({ organiserCode: undefined });
+        await user.click(screen.getByRole("button", { name: /^partager$/i }));
+        expect(screen.getByRole("menuitem", { name: /code orga/i })).toBeDisabled();
+    });
+
+    it("désactive le partage sans aucun code", () => {
+        setup({ shareCode: undefined, organiserCode: undefined });
         expect(screen.getByRole("button", { name: /partage indisponible/i })).toBeDisabled();
     });
 

--- a/src/components/History/ItineraryCard.tsx
+++ b/src/components/History/ItineraryCard.tsx
@@ -1,13 +1,15 @@
+import { useState } from "react";
 import { Trash2, Share2, Download, FileDown } from "lucide-react";
 import { ConvoyThumbnail } from "./ConvoyThumbnail";
 import type { ItineraryResponse, SegmentResponse } from "../../customObject/Itinerary/netTypes";
 import { downloadGpx, hasGpxGeometry } from "../../customObject/Itinerary/gpx.ts";
+import useOutsideClick from "../useOutsideClick.ts";
 
 interface ItineraryCardProps {
     itinerary: ItineraryResponse;
     onOpen: (id: number) => void;
     onDelete: (id: number) => void;
-    onShare: (shareCode: string) => void;
+    onShare: (code: string, label: string) => void;
     onExportPdf: (id: number) => void;
     isExportingPdf?: boolean;
 }
@@ -57,6 +59,8 @@ export function ItineraryCard({
     onExportPdf,
     isExportingPdf = false,
 }: ItineraryCardProps) {
+    const [showShareMenu, setShowShareMenu] = useState(false);
+    const shareRef = useOutsideClick<HTMLDivElement>(() => setShowShareMenu(false));
     const segs = segmentsList(itinerary);
     const status = getStatus(itinerary);
     const canDownloadGpx = hasGpxGeometry(segs.map((segment) => ({
@@ -69,10 +73,16 @@ export function ItineraryCard({
     const pdfLabel = isExportingPdf
         ? "G\u00e9n\u00e9ration du PDF..."
         : "Exporter en PDF";
-    const shareLabel = itinerary.shareCode
+    const canShare = Boolean(itinerary.shareCode) || Boolean(itinerary.organiserCode);
+    const shareLabel = canShare
         ? "Partager"
         : "Partage indisponible";
     const deleteLabel = "Supprimer";
+
+    const handleSelectShare = (code: string, label: string) => {
+        setShowShareMenu(false);
+        onShare(code, label);
+    };
 
     return (
         <div className="ch-card">
@@ -129,15 +139,43 @@ export function ItineraryCard({
                     >
                         <FileDown size={16} color={isExportingPdf || !canExportPdf ? "#ccc" : "#BB487C"} />
                     </button>
-                    <button
-                        className="ch-btn-icon"
-                        onClick={() => itinerary.shareCode && onShare(itinerary.shareCode)}
-                        aria-label={shareLabel}
-                        title={shareLabel}
-                        disabled={!itinerary.shareCode}
-                    >
-                        <Share2 size={16} color={itinerary.shareCode ? "#BB487C" : "#ccc"} />
-                    </button>
+                    <div className="ch-share-wrapper" ref={shareRef}>
+                        <button
+                            className="ch-btn-icon"
+                            onClick={() => setShowShareMenu((prev) => !prev)}
+                            aria-label={shareLabel}
+                            title={shareLabel}
+                            aria-haspopup="menu"
+                            aria-expanded={showShareMenu}
+                            disabled={!canShare}
+                        >
+                            <Share2 size={16} color={canShare ? "#BB487C" : "#ccc"} />
+                        </button>
+                        {showShareMenu && (
+                            <div className="ch-share-menu" role="menu">
+                                <button
+                                    type="button"
+                                    className="ch-share-menu-item"
+                                    role="menuitem"
+                                    onClick={() => handleSelectShare(itinerary.shareCode ?? "", "Code membre")}
+                                    disabled={!itinerary.shareCode}
+                                >
+                                    <Share2 size={14} />
+                                    Code membre
+                                </button>
+                                <button
+                                    type="button"
+                                    className="ch-share-menu-item"
+                                    role="menuitem"
+                                    onClick={() => handleSelectShare(itinerary.organiserCode ?? "", "Code orga")}
+                                    disabled={!itinerary.organiserCode}
+                                >
+                                    <Share2 size={14} />
+                                    Code orga
+                                </button>
+                            </div>
+                        )}
+                    </div>
                     <button
                         className="ch-btn-icon"
                         onClick={() => onDelete(itinerary.id)}

--- a/src/components/Panels/ActionButtons.test.tsx
+++ b/src/components/Panels/ActionButtons.test.tsx
@@ -6,6 +6,7 @@ const mockItinerary = {
     id: 1,
     name: 'Convoi test',
     shareCode: '',
+    organiserCode: '',
     segments: [{ id: 'seg-1', content: { geometry: { type: 'Feature' } } }],
 };
 
@@ -86,5 +87,43 @@ describe('ActionButtons export menu', () => {
         await user.click(screen.getByLabelText("Exporter l'itinéraire"));
 
         expect(screen.getByText('Téléchargement GPX indisponible').closest('button')).toBeDisabled();
+    });
+});
+
+describe('ActionButtons share menu', () => {
+    beforeEach(() => {
+        mockItinerary.shareCode = 'MEMBER1';
+        mockItinerary.organiserCode = 'ORGA1';
+    });
+
+    it('propose le partage du code membre et du code orga', async () => {
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByRole('button', { name: /^partager$/i }));
+
+        expect(screen.getByText('Partager le code membre')).toBeInTheDocument();
+        expect(screen.getByText('Partager le code orga')).toBeInTheDocument();
+    });
+
+    it('affiche le code orga dans la modale de partage', async () => {
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByRole('button', { name: /^partager$/i }));
+        await user.click(screen.getByText('Partager le code orga'));
+
+        expect(screen.getByText('ORGA1')).toBeInTheDocument();
+        expect(screen.getByText('Code orga :')).toBeInTheDocument();
+    });
+
+    it('désactive le choix code orga quand il est absent', async () => {
+        mockItinerary.organiserCode = '';
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByRole('button', { name: /^partager$/i }));
+
+        expect(screen.getByText('Partager le code orga').closest('button')).toBeDisabled();
     });
 });

--- a/src/components/Panels/ActionButtons.tsx
+++ b/src/components/Panels/ActionButtons.tsx
@@ -40,9 +40,11 @@ export default function ActionButtons() {
     const itinerary = useItinerary(itineraryModel.store);
     const isDirty = useIsDirty();
     const [showSettings, setShowSettings] = useState(false);
-    const [showShare, setShowShare] = useState(false);
+    const [showShareMenu, setShowShareMenu] = useState(false);
+    const [shareTarget, setShareTarget] = useState<{ code: string; label: string } | null>(null);
     const [showExport, setShowExport] = useState(false);
     const exportRef = useOutsideClick<HTMLDivElement>(() => setShowExport(false));
+    const shareRef = useOutsideClick<HTMLDivElement>(() => setShowShareMenu(false));
     const [currentSettings, setCurrentSettings] = useState<GlobalSettings | undefined>(undefined);
     const [isExportingPdf, setIsExportingPdf] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
@@ -54,7 +56,8 @@ export default function ActionButtons() {
     const deleteModeLabel = delMod
         ? "Quitter le mode suppression"
         : "Activer le mode suppression";
-    const shareLabel = itinerary.shareCode
+    const canShare = Boolean(itinerary.shareCode) || Boolean(itinerary.organiserCode);
+    const shareLabel = canShare
         ? "Partager"
         : "Partage indisponible";
     const downloadLabel = canDownloadGpx
@@ -125,6 +128,11 @@ export default function ActionButtons() {
         await handleExportPdf();
     };
 
+    const handleSelectShare = (code: string, label: string) => {
+        setShowShareMenu(false);
+        setShareTarget({ code, label });
+    };
+
     return (
         <>
             <div className={"action-buttons"}>
@@ -147,15 +155,43 @@ export default function ActionButtons() {
                         : <Trash color={"#BB487C"} />
                     }
                 </button>
-                <button
-                    className={"share-btn"}
-                    aria-label={shareLabel}
-                    title={shareLabel}
-                    onClick={() => setShowShare(true)}
-                    disabled={!itinerary.shareCode}
-                >
-                    <Share2 color={itinerary.shareCode ? "#BB487C" : "#ccc"} />
-                </button>
+                <div className={"export-menu-wrapper"} ref={shareRef}>
+                    <button
+                        className={"share-btn"}
+                        aria-label={shareLabel}
+                        title={shareLabel}
+                        aria-haspopup={"menu"}
+                        aria-expanded={showShareMenu}
+                        onClick={() => setShowShareMenu((prev) => !prev)}
+                        disabled={!canShare}
+                    >
+                        <Share2 color={canShare ? "#BB487C" : "#ccc"} />
+                    </button>
+                    {showShareMenu && (
+                        <div className={"export-menu"} role={"menu"}>
+                            <button
+                                type={"button"}
+                                className={"export-menu-item"}
+                                role={"menuitem"}
+                                onClick={() => handleSelectShare(itinerary.shareCode, "Code membre")}
+                                disabled={!itinerary.shareCode}
+                            >
+                                <Share2 size={16} />
+                                Partager le code membre
+                            </button>
+                            <button
+                                type={"button"}
+                                className={"export-menu-item"}
+                                role={"menuitem"}
+                                onClick={() => handleSelectShare(itinerary.organiserCode ?? "", "Code orga")}
+                                disabled={!itinerary.organiserCode}
+                            >
+                                <Share2 size={16} />
+                                Partager le code orga
+                            </button>
+                        </div>
+                    )}
+                </div>
                 <div className={"export-menu-wrapper"} ref={exportRef}>
                     <button
                         className={"export-btn"}
@@ -223,10 +259,11 @@ export default function ActionButtons() {
                 />
             )}
 
-            {showShare && itinerary.shareCode && (
+            {shareTarget && (
                 <ShareModal
-                    shareCode={itinerary.shareCode}
-                    onClose={() => setShowShare(false)}
+                    shareCode={shareTarget.code}
+                    codeLabel={shareTarget.label}
+                    onClose={() => setShareTarget(null)}
                 />
             )}
         </>

--- a/src/components/Panels/ShareModal.tsx
+++ b/src/components/Panels/ShareModal.tsx
@@ -6,10 +6,12 @@ import './ShareModal.css';
 
 type ShareModalProps = {
     shareCode: string;
+    /** Libellé du code affiché (ex. « Code membre » ou « Code orga »). Défaut : « Code ». */
+    codeLabel?: string;
     onClose: () => void;
 }
 
-export default function ShareModal({ shareCode, onClose }: ShareModalProps) {
+export default function ShareModal({ shareCode, codeLabel = "Code", onClose }: ShareModalProps) {
     const [copied, setCopied] = useState(false);
 
     useEffect(() => {
@@ -56,7 +58,7 @@ export default function ShareModal({ shareCode, onClose }: ShareModalProps) {
                 </div>
 
                 <div className="share-code-row">
-                    <span className="share-code-label">Code :</span>
+                    <span className="share-code-label">{codeLabel} :</span>
                     <span className="share-code-value">{shareCode}</span>
                     <button className="share-copy-btn" onClick={handleCopy} aria-label="Copier le code">
                         {copied ? <Check size={16} color="#4caf50" /> : <Copy size={16} color="#BB487C" />}

--- a/src/customObject/Itinerary/ItineraryModel.ts
+++ b/src/customObject/Itinerary/ItineraryModel.ts
@@ -65,6 +65,7 @@ class ItineraryModel {
                 id: -1,
                 name: "Nouveau Convoi",
                 shareCode: "",
+                organiserCode: "",
                 totalDuration: new TimeSpan(),
                 totalDistance: 0,
                 segments: [],

--- a/src/customObject/Itinerary/ItineraryNetModel.ts
+++ b/src/customObject/Itinerary/ItineraryNetModel.ts
@@ -377,6 +377,7 @@ export class ItineraryNetModel {
                 id: response.id,
                 name: response.name,
                 shareCode: response.shareCode ?? "",
+                organiserCode: response.organiserCode ?? "",
                 totalDuration: new TimeSpan(totalDurationSec * 1000),
                 totalDistance: totalDistanceM * 0.001,
                 segments: updateStarts(segments),

--- a/src/customObject/Itinerary/ItineraryStore.ts
+++ b/src/customObject/Itinerary/ItineraryStore.ts
@@ -10,6 +10,7 @@ export function createItineraryStore(initial?: Itinerary): ItineraryStore
             id: -1,
             name: "Nouveau Convoi",
             shareCode: "",
+            organiserCode: "",
             totalDuration: new TimeSpan(),
             totalDistance: 0,
             segments: new Array<Segment>(),

--- a/src/customObject/Itinerary/itineraryResponseMapper.ts
+++ b/src/customObject/Itinerary/itineraryResponseMapper.ts
@@ -126,6 +126,7 @@ export function itineraryResponseToItinerary(response: ItineraryResponse): Itine
         id: response.id,
         name: response.name,
         shareCode: response.shareCode ?? "",
+        organiserCode: response.organiserCode ?? "",
         totalDuration: new TimeSpan((response.totalDuration ?? 0) * 1000),
         totalDistance: (response.totalDistance ?? 0) * 0.001,
         segments: updateStarts(normalizeSegments(response.segments ?? [], response.departureTime, refId)),

--- a/src/customObject/Itinerary/types.ts
+++ b/src/customObject/Itinerary/types.ts
@@ -48,6 +48,8 @@ export type Itinerary = {
     id: number;
     name: string;
     shareCode: string;
+    /** Code réservé aux organisateurs ; absent tant que l'itinéraire n'a pas été chargé/enregistré */
+    organiserCode?: string;
     totalDuration: TimeSpan;
     totalDistance: number;
     segments: Segment[];

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -31,7 +31,7 @@ export default function HistoryPage() {
     const [clientPage, setClientPage] = useState(0);
     const [totalPages, setTotalPages] = useState(0);
     const [totalElements, setTotalElements] = useState(0);
-    const [shareCode, setShareCode] = useState<string | null>(null);
+    const [shareTarget, setShareTarget] = useState<{ code: string; label: string } | null>(null);
     const [exportingId, setExportingId] = useState<number | null>(null);
 
     const isFiltered = filter !== 'all';
@@ -249,7 +249,7 @@ export default function HistoryPage() {
                                 itinerary={itinerary}
                                 onOpen={handleOpenConvoy}
                                 onDelete={handleDelete}
-                                onShare={setShareCode}
+                                onShare={(code, label) => setShareTarget({ code, label })}
                                 onExportPdf={handleExportPdf}
                                 isExportingPdf={exportingId === itinerary.id}
                             />
@@ -282,8 +282,12 @@ export default function HistoryPage() {
             </main>
         </div>
 
-        {shareCode && (
-            <ShareModal shareCode={shareCode} onClose={() => setShareCode(null)} />
+        {shareTarget && (
+            <ShareModal
+                shareCode={shareTarget.code}
+                codeLabel={shareTarget.label}
+                onClose={() => setShareTarget(null)}
+            />
         )}
         </>
     );


### PR DESCRIPTION
## Objectif

Afficher le **code orga** en plus du **code membre** déjà présent, et transformer les boutons de partage en menu de choix — sur le même modèle que le menu d'export GPX/PDF.

## Comportement

Clic sur **Partager** → menu déroulant :

- **Code membre** (l'ancien `shareCode`)
- **Code orga** (le nouveau `organiserCode`)

Le choix ouvre la `ShareModal` (QR code + copie) avec le libellé correspondant (« Code membre : » / « Code orga : »). Chaque option est grisée si son code est absent ; le bouton Partager entier est désactivé uniquement s'il n'y a aucun des deux codes.

Les deux emplacements de partage sont couverts : la barre d'actions du planificateur (`ActionButtons`) et les cartes de l'historique (`ItineraryCard`).

## Détails techniques

- `organiserCode?` ajouté au modèle de store `Itinerary` et propagé depuis l'API (`itineraryResponseMapper`, `ItineraryNetModel.applyItinerary`, valeurs par défaut de `ItineraryModel.reset` / `ItineraryStore`).
- `ShareModal` reçoit une prop `codeLabel` (défaut « Code ») pour afficher quel code est partagé.
- `organiserCode` est **optionnel** (et non requis comme `shareCode`) pour ne pas casser les fixtures de test existantes ; les chemins de production le remplissent toujours (`?? ""`).

## Tests

- `tsc -b`, `eslint` et la suite complète passent (**41 fichiers / 339 tests**).
- Nouveaux tests : partage membre / orga et désactivation quand un code manque, côté `ItineraryCard` et `ActionButtons`.

## Dépendance backend

S'appuie sur le champ `organiserCode` de `ItineraryResponse`. Si l'endpoint `/tours` ne le renvoie pas encore, l'option « Code orga » restera désactivée jusqu'à ce que le backend l'expose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
