### PR TITLE
Validation de la durée des segments à la sauvegarde

### DIFF
--- a/src/components/Panels/ActionButtons.test.tsx
+++ b/src/components/Panels/ActionButtons.test.tsx
@@ -21,8 +21,33 @@ vi.mock('../../customObject/SaveState/useIsDirty', () => ({
 vi.mock('../../customObject/DeleteMod/DeleteModStore', () => ({
     deleteModStore: { set: vi.fn() },
 }));
+const { saveAsDraft, saveAsFinalized } = vi.hoisted(() => ({
+    saveAsDraft: vi.fn(() => Promise.resolve()),
+    saveAsFinalized: vi.fn(() => Promise.resolve()),
+}));
 vi.mock('../../customObject/Itinerary/ItineraryStore', () => ({
-    itineraryModel: { store: {}, netModel: {} },
+    itineraryModel: { store: {}, netModel: { saveAsDraft, saveAsFinalized } },
+}));
+
+const { pushErrorToast } = vi.hoisted(() => ({
+    pushErrorToast: vi.fn(),
+}));
+vi.mock('../../customObject/Toast/ToastStore', () => ({
+    pushErrorToast,
+}));
+
+const { findSegmentDurationViolations, buildSegmentDurationErrorMessage } = vi.hoisted(() => ({
+    findSegmentDurationViolations: vi.fn(() => []),
+    buildSegmentDurationErrorMessage: vi.fn(() => 'Segment hors bornes'),
+}));
+vi.mock('../../customObject/Itinerary/segmentDurationValidation', () => ({
+    findSegmentDurationViolations,
+    buildSegmentDurationErrorMessage,
+}));
+
+vi.mock('../SettingsModal/settingsStorage', () => ({
+    loadGlobalSettings: () => ({ minSegmentDuration: 1, maxSegmentDuration: 4 }),
+    persistGlobalSettings: vi.fn(),
 }));
 
 const { downloadGpx, hasGpxGeometry, downloadItineraryPdf } = vi.hoisted(() => ({
@@ -86,5 +111,50 @@ describe('ActionButtons export menu', () => {
         await user.click(screen.getByLabelText("Exporter l'itinéraire"));
 
         expect(screen.getByText('Téléchargement GPX indisponible').closest('button')).toBeDisabled();
+    });
+});
+
+describe('ActionButtons sauvegarde et durée des segments', () => {
+    beforeEach(() => {
+        saveAsDraft.mockClear();
+        saveAsFinalized.mockClear();
+        pushErrorToast.mockClear();
+        findSegmentDurationViolations.mockReturnValue([]);
+    });
+
+    it('enregistre le convoi quand toutes les durées sont valides', async () => {
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+        expect(saveAsFinalized).toHaveBeenCalledTimes(1);
+        expect(pushErrorToast).not.toHaveBeenCalled();
+    });
+
+    it('bloque la sauvegarde et affiche une erreur quand un segment est hors bornes', async () => {
+        findSegmentDurationViolations.mockReturnValue([
+            { segmentName: 'Segment a', durationLabel: '5h00', kind: 'max' },
+        ]);
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByRole('button', { name: 'Enregistrer' }));
+
+        expect(saveAsFinalized).not.toHaveBeenCalled();
+        expect(pushErrorToast).toHaveBeenCalledWith('Segment hors bornes');
+    });
+
+    it('bloque aussi la sauvegarde en brouillon', async () => {
+        findSegmentDurationViolations.mockReturnValue([
+            { segmentName: 'Segment a', durationLabel: '0h30', kind: 'min' },
+        ]);
+        const user = userEvent.setup();
+        render(<ActionButtons />);
+
+        await user.click(screen.getByRole('button', { name: 'Brouillon' }));
+
+        expect(saveAsDraft).not.toHaveBeenCalled();
+        expect(pushErrorToast).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/components/Panels/ActionButtons.test.tsx
+++ b/src/components/Panels/ActionButtons.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { SegmentDurationViolation } from '../../customObject/Itinerary/segmentDurationValidation.ts';
 
 const mockItinerary = {
     id: 1,
@@ -37,7 +38,7 @@ vi.mock('../../customObject/Toast/ToastStore', () => ({
 }));
 
 const { findSegmentDurationViolations, buildSegmentDurationErrorMessage } = vi.hoisted(() => ({
-    findSegmentDurationViolations: vi.fn(() => []),
+    findSegmentDurationViolations: vi.fn((): SegmentDurationViolation[] => []),
     buildSegmentDurationErrorMessage: vi.fn(() => 'Segment hors bornes'),
 }));
 vi.mock('../../customObject/Itinerary/segmentDurationValidation', () => ({

--- a/src/components/Panels/ActionButtons.tsx
+++ b/src/components/Panels/ActionButtons.tsx
@@ -14,6 +14,10 @@ import { downloadGpx, hasGpxGeometry } from "../../customObject/Itinerary/gpx.ts
 import { downloadItineraryPdf, collectPdfSections } from "../../customObject/Itinerary/pdf.ts";
 import { pushErrorToast } from "../../customObject/Toast/ToastStore.ts";
 import { useIsDirty } from "../../customObject/SaveState/useIsDirty.ts";
+import {
+    buildSegmentDurationErrorMessage,
+    findSegmentDurationViolations,
+} from "../../customObject/Itinerary/segmentDurationValidation.ts";
 
 function buildDepartureDateTime(departureDate: string, departureTime: string): Date | null {
     if (!departureDate || !departureTime) {
@@ -86,13 +90,29 @@ export default function ActionButtons() {
         itineraryModel.applySegmentPauseConfigs(settings.pauseConfigs);
     };
 
+    const hasValidSegmentDurations = (): boolean => {
+        const settings = loadGlobalSettings(itinerary);
+        const violations = findSegmentDurationViolations(itinerary, settings);
+        if (violations.length > 0) {
+            pushErrorToast(buildSegmentDurationErrorMessage(violations, settings));
+            return false;
+        }
+        return true;
+    };
+
     const handleSaveAsDraft = async () => {
+        if (!hasValidSegmentDurations()) {
+            return;
+        }
         setIsSaving(true);
         await itineraryModel.netModel.saveAsDraft();
         setIsSaving(false);
     };
 
     const handleSaveAsFinalized = async () => {
+        if (!hasValidSegmentDurations()) {
+            return;
+        }
         setIsSaving(true);
         await itineraryModel.netModel.saveAsFinalized();
         setIsSaving(false);

--- a/src/customObject/Itinerary/segmentDurationValidation.test.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+    buildSegmentDurationErrorMessage,
+    findSegmentDurationViolations,
+} from "./segmentDurationValidation.ts";
+import type { Itinerary, Segment } from "./types.ts";
+import type { GlobalSettings } from "../../components/SettingsModal/settingsTypes.ts";
+import { TimeSpan } from "../TimeSpan.ts";
+
+const HOUR_MS = 3_600_000;
+
+function makeSegment(id: string, hours: number, overrides: Partial<Segment> = {}): Segment {
+    return {
+        id,
+        isStartEnd: false,
+        steps: [],
+        content: {
+            title: `Segment ${id}`,
+            hour: new Date(),
+            duration: new TimeSpan(hours * HOUR_MS),
+            distance: 0,
+        },
+        ...overrides,
+    };
+}
+
+function makeItinerary(segments: Segment[]): Itinerary {
+    return {
+        id: 1,
+        name: "Convoi",
+        shareCode: "",
+        totalDuration: new TimeSpan(),
+        totalDistance: 0,
+        segments,
+        draft: true,
+    };
+}
+
+const bounds: Pick<GlobalSettings, "minSegmentDuration" | "maxSegmentDuration"> = {
+    minSegmentDuration: 1,
+    maxSegmentDuration: 4,
+};
+
+describe("findSegmentDurationViolations", () => {
+    it("ne retourne aucune violation quand tous les segments sont dans les bornes", () => {
+        const itinerary = makeItinerary([makeSegment("a", 2), makeSegment("b", 3.5)]);
+
+        expect(findSegmentDurationViolations(itinerary, bounds)).toEqual([]);
+    });
+
+    it("signale un segment trop court", () => {
+        const itinerary = makeItinerary([makeSegment("a", 0.5)]);
+
+        const violations = findSegmentDurationViolations(itinerary, bounds);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].kind).toBe("min");
+        expect(violations[0].durationLabel).toBe("0h30");
+    });
+
+    it("signale un segment trop long", () => {
+        const itinerary = makeItinerary([makeSegment("a", 5)]);
+
+        const violations = findSegmentDurationViolations(itinerary, bounds);
+
+        expect(violations).toHaveLength(1);
+        expect(violations[0].kind).toBe("max");
+    });
+
+    it("accepte les segments exactement aux bornes", () => {
+        const itinerary = makeItinerary([makeSegment("a", 1), makeSegment("b", 4)]);
+
+        expect(findSegmentDurationViolations(itinerary, bounds)).toEqual([]);
+    });
+
+    it("ignore les segments de départ/arrivée", () => {
+        const itinerary = makeItinerary([
+            makeSegment("start", 0, { isStartEnd: true }),
+            makeSegment("end", 0, { isStartEnd: true }),
+        ]);
+
+        expect(findSegmentDurationViolations(itinerary, bounds)).toEqual([]);
+    });
+});
+
+describe("buildSegmentDurationErrorMessage", () => {
+    it("mentionne le nom du segment et la borne dépassée", () => {
+        const itinerary = makeItinerary([makeSegment("a", 5)]);
+        const violations = findSegmentDurationViolations(itinerary, bounds);
+
+        const message = buildSegmentDurationErrorMessage(violations, bounds);
+
+        expect(message).toContain("Segment a");
+        expect(message).toContain("maximum de 4h");
+        expect(message).toContain("Impossible d'enregistrer");
+    });
+});

--- a/src/customObject/Itinerary/segmentDurationValidation.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.ts
@@ -1,0 +1,76 @@
+import type { Itinerary, Segment } from "./types.ts";
+import type { GlobalSettings } from "../../components/SettingsModal/settingsTypes.ts";
+import { TimeSpan } from "../TimeSpan.ts";
+
+const MS_PER_HOUR = 3_600_000;
+
+export type SegmentDurationBounds = Pick<GlobalSettings, "minSegmentDuration" | "maxSegmentDuration">;
+
+export type SegmentDurationViolation = {
+    segmentName: string;
+    durationLabel: string;
+    kind: "min" | "max";
+};
+
+function isCheckableSegment(segment: Segment): boolean {
+    return !segment.isStartEnd && segment.id !== "start" && segment.id !== "end";
+}
+
+function normalizeDuration(duration?: TimeSpan): TimeSpan {
+    return Object.assign(new TimeSpan(), duration);
+}
+
+function formatDurationLabel(duration?: TimeSpan): string {
+    const composed = normalizeDuration(duration).getTimeSpanComposed();
+    const totalHours = composed.days * 24 + composed.hours;
+    return `${totalHours}h${String(composed.minutes).padStart(2, "0")}`;
+}
+
+/**
+ * Recense les segments dont la durée sort des bornes min/max définies dans les
+ * paramètres globaux. Les segments de départ/arrivée sont ignorés.
+ * @param itinerary itinéraire à contrôler
+ * @param bounds durées min et max autorisées, en heures
+ */
+export function findSegmentDurationViolations(
+    itinerary: Itinerary,
+    bounds: SegmentDurationBounds
+): SegmentDurationViolation[] {
+    const { minSegmentDuration, maxSegmentDuration } = bounds;
+
+    return itinerary.segments.filter(isCheckableSegment).flatMap((segment) => {
+        const hours = normalizeDuration(segment.content.duration).duration / MS_PER_HOUR;
+        const segmentName = segment.content.title || "Segment sans nom";
+        const durationLabel = formatDurationLabel(segment.content.duration);
+
+        if (hours < minSegmentDuration) {
+            return [{ segmentName, durationLabel, kind: "min" as const }];
+        }
+        if (hours > maxSegmentDuration) {
+            return [{ segmentName, durationLabel, kind: "max" as const }];
+        }
+        return [];
+    });
+}
+
+/**
+ * Construit le message d'erreur affiché lorsqu'un ou plusieurs segments ne
+ * respectent pas les bornes de durée.
+ * @param violations segments hors bornes
+ * @param bounds durées min et max autorisées, en heures
+ */
+export function buildSegmentDurationErrorMessage(
+    violations: SegmentDurationViolation[],
+    bounds: SegmentDurationBounds
+): string {
+    const details = violations
+        .map((violation) => {
+            const bound = violation.kind === "min"
+                ? `en dessous du minimum de ${bounds.minSegmentDuration}h`
+                : `au-dessus du maximum de ${bounds.maxSegmentDuration}h`;
+            return `« ${violation.segmentName} » (${violation.durationLabel}) est ${bound}`;
+        })
+        .join(" ; ");
+
+    return `Impossible d'enregistrer : ${details}.`;
+}

--- a/src/customObject/Itinerary/segmentDurationValidation.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.ts
@@ -38,16 +38,16 @@ export function findSegmentDurationViolations(
 ): SegmentDurationViolation[] {
     const { minSegmentDuration, maxSegmentDuration } = bounds;
 
-    return itinerary.segments.filter(isCheckableSegment).flatMap((segment) => {
+    return itinerary.segments.filter(isCheckableSegment).flatMap((segment): SegmentDurationViolation[] => {
         const hours = normalizeDuration(segment.content.duration).duration / MS_PER_HOUR;
         const segmentName = segment.content.title || "Segment sans nom";
         const durationLabel = formatDurationLabel(segment.content.duration);
 
         if (hours < minSegmentDuration) {
-            return [{ segmentName, durationLabel, kind: "min" as const }];
+            return [{ segmentName, durationLabel, kind: "min" }];
         }
         if (hours > maxSegmentDuration) {
-            return [{ segmentName, durationLabel, kind: "max" as const }];
+            return [{ segmentName, durationLabel, kind: "max" }];
         }
         return [];
     });


### PR DESCRIPTION
## Contexte

Les paramètres globaux définissent une durée **min** et **max** par segment (`minSegmentDuration` / `maxSegmentDuration`), mais ces bornes n'étaient **jamais contrôlées**. Cette PR ajoute la validation au moment de la sauvegarde.

## Changements

- **`segmentDurationValidation.ts`** (nouveau) :
  - `findSegmentDurationViolations(itinerary, bounds)` — repère les segments (hors départ/arrivée) dont la durée en heures sort des bornes.
  - `buildSegmentDurationErrorMessage(...)` — construit le message d'erreur en français.
- **`ActionButtons.tsx`** — un garde `hasValidSegmentDurations()` bloque **Brouillon** et **Enregistrer** et affiche un toast d'erreur si un segment est hors bornes.

## Comportement

- Un segment exactement à la borne (min ou max) est accepté.
- Message ex. : « Impossible d'enregistrer : « Segment 3 » (5h00) est au-dessus du maximum de 4h. »

## Tests

- Unitaires sur la validation (dans/hors bornes, aux bornes, départ/arrivée ignorés, message).
- Intégration `ActionButtons` : save autorisé si valide, bloqué + toast sinon (brouillon et finalisé).