### PR TITLE
Surbrillance des segments hors bornes (au lieu du blocage à la sauvegarde)

### DIFF
--- a/src/components/Panels/ActionButtons.test.tsx
+++ b/src/components/Panels/ActionButtons.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { SegmentDurationViolation } from '../../customObject/Itinerary/segmentDurationValidation.ts';
 
 const mockItinerary = {
     id: 1,
@@ -23,33 +22,8 @@ vi.mock('../../customObject/SaveState/useIsDirty', () => ({
 vi.mock('../../customObject/DeleteMod/DeleteModStore', () => ({
     deleteModStore: { set: vi.fn() },
 }));
-const { saveAsDraft, saveAsFinalized } = vi.hoisted(() => ({
-    saveAsDraft: vi.fn(() => Promise.resolve()),
-    saveAsFinalized: vi.fn(() => Promise.resolve()),
-}));
 vi.mock('../../customObject/Itinerary/ItineraryStore', () => ({
-    itineraryModel: { store: {}, netModel: { saveAsDraft, saveAsFinalized } },
-}));
-
-const { pushErrorToast } = vi.hoisted(() => ({
-    pushErrorToast: vi.fn(),
-}));
-vi.mock('../../customObject/Toast/ToastStore', () => ({
-    pushErrorToast,
-}));
-
-const { findSegmentDurationViolations, buildSegmentDurationErrorMessage } = vi.hoisted(() => ({
-    findSegmentDurationViolations: vi.fn((): SegmentDurationViolation[] => []),
-    buildSegmentDurationErrorMessage: vi.fn(() => 'Segment hors bornes'),
-}));
-vi.mock('../../customObject/Itinerary/segmentDurationValidation', () => ({
-    findSegmentDurationViolations,
-    buildSegmentDurationErrorMessage,
-}));
-
-vi.mock('../SettingsModal/settingsStorage', () => ({
-    loadGlobalSettings: () => ({ minSegmentDuration: 1, maxSegmentDuration: 4 }),
-    persistGlobalSettings: vi.fn(),
+    itineraryModel: { store: {}, netModel: {} },
 }));
 
 const { downloadGpx, hasGpxGeometry, downloadItineraryPdf } = vi.hoisted(() => ({
@@ -151,50 +125,5 @@ describe('ActionButtons share menu', () => {
         await user.click(screen.getByRole('button', { name: /^partager$/i }));
 
         expect(screen.getByText('Partager le code orga').closest('button')).toBeDisabled();
-    });
-});
-
-describe('ActionButtons sauvegarde et durée des segments', () => {
-    beforeEach(() => {
-        saveAsDraft.mockClear();
-        saveAsFinalized.mockClear();
-        pushErrorToast.mockClear();
-        findSegmentDurationViolations.mockReturnValue([]);
-    });
-
-    it('enregistre le convoi quand toutes les durées sont valides', async () => {
-        const user = userEvent.setup();
-        render(<ActionButtons />);
-
-        await user.click(screen.getByRole('button', { name: 'Enregistrer' }));
-
-        expect(saveAsFinalized).toHaveBeenCalledTimes(1);
-        expect(pushErrorToast).not.toHaveBeenCalled();
-    });
-
-    it('bloque la sauvegarde et affiche une erreur quand un segment est hors bornes', async () => {
-        findSegmentDurationViolations.mockReturnValue([
-            { segmentName: 'Segment a', durationLabel: '5h00', kind: 'max' },
-        ]);
-        const user = userEvent.setup();
-        render(<ActionButtons />);
-
-        await user.click(screen.getByRole('button', { name: 'Enregistrer' }));
-
-        expect(saveAsFinalized).not.toHaveBeenCalled();
-        expect(pushErrorToast).toHaveBeenCalledWith('Segment hors bornes');
-    });
-
-    it('bloque aussi la sauvegarde en brouillon', async () => {
-        findSegmentDurationViolations.mockReturnValue([
-            { segmentName: 'Segment a', durationLabel: '0h30', kind: 'min' },
-        ]);
-        const user = userEvent.setup();
-        render(<ActionButtons />);
-
-        await user.click(screen.getByRole('button', { name: 'Brouillon' }));
-
-        expect(saveAsDraft).not.toHaveBeenCalled();
-        expect(pushErrorToast).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/components/Panels/ActionButtons.tsx
+++ b/src/components/Panels/ActionButtons.tsx
@@ -14,10 +14,6 @@ import { downloadGpx, hasGpxGeometry } from "../../customObject/Itinerary/gpx.ts
 import { downloadItineraryPdf, collectPdfSections } from "../../customObject/Itinerary/pdf.ts";
 import { pushErrorToast } from "../../customObject/Toast/ToastStore.ts";
 import { useIsDirty } from "../../customObject/SaveState/useIsDirty.ts";
-import {
-    buildSegmentDurationErrorMessage,
-    findSegmentDurationViolations,
-} from "../../customObject/Itinerary/segmentDurationValidation.ts";
 
 function buildDepartureDateTime(departureDate: string, departureTime: string): Date | null {
     if (!departureDate || !departureTime) {
@@ -93,29 +89,13 @@ export default function ActionButtons() {
         itineraryModel.applySegmentPauseConfigs(settings.pauseConfigs);
     };
 
-    const hasValidSegmentDurations = (): boolean => {
-        const settings = loadGlobalSettings(itinerary);
-        const violations = findSegmentDurationViolations(itinerary, settings);
-        if (violations.length > 0) {
-            pushErrorToast(buildSegmentDurationErrorMessage(violations, settings));
-            return false;
-        }
-        return true;
-    };
-
     const handleSaveAsDraft = async () => {
-        if (!hasValidSegmentDurations()) {
-            return;
-        }
         setIsSaving(true);
         await itineraryModel.netModel.saveAsDraft();
         setIsSaving(false);
     };
 
     const handleSaveAsFinalized = async () => {
-        if (!hasValidSegmentDurations()) {
-            return;
-        }
         setIsSaving(true);
         await itineraryModel.netModel.saveAsFinalized();
         setIsSaving(false);

--- a/src/components/Panels/DragNDrop/SortableCategory.test.tsx
+++ b/src/components/Panels/DragNDrop/SortableCategory.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import type { Segment } from '../../../customObject/Itinerary/types';
+import { TimeSpan } from '../../../customObject/TimeSpan';
+
+vi.mock('./SortableStepHeader', () => ({
+    default: ({ durationHint }: { durationHint?: string | null }) => (
+        <div data-testid="header" data-hint={durationHint ?? ''} />
+    ),
+}));
+vi.mock('./SortablePDP', () => ({ default: () => <div /> }));
+vi.mock('./EmptyDropZone', () => ({ EmptyDropZone: () => <div /> }));
+vi.mock('../../../customObject/Itinerary/ItineraryStore', () => ({
+    itineraryModel: {},
+}));
+
+import SortableCategory from './SortableCategory';
+
+function segment(id: string): Segment {
+    return {
+        id,
+        isStartEnd: false,
+        content: { title: id, hour: new Date(), duration: new TimeSpan(), distance: 0 },
+        steps: [],
+    };
+}
+
+function renderCategory(durationHint: string | null) {
+    return render(
+        <DndContext>
+            <SortableCategory category={segment('seg-1')} visible={true} idActiveItem={null} durationHint={durationHint} />
+        </DndContext>
+    );
+}
+
+describe('SortableCategory surbrillance durée', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('transmet le hint au header pour la surbrillance', () => {
+        renderCategory('Segment trop long');
+
+        expect(screen.getByTestId('header')).toHaveAttribute('data-hint', 'Segment trop long');
+    });
+
+    it("n'affiche pas de message au montage même si le segment est déjà hors bornes", () => {
+        renderCategory('Segment trop long');
+
+        expect(screen.queryByText('Segment trop long')).not.toBeInTheDocument();
+    });
+
+    it('affiche un message transitoire quand le segment devient hors bornes, puis le masque', () => {
+        const message = 'Segment trop court : 0h30 (min 1h)';
+        const { rerender } = renderCategory(null);
+
+        act(() => {
+            rerender(
+                <DndContext>
+                    <SortableCategory category={segment('seg-1')} visible={true} idActiveItem={null} durationHint={message} />
+                </DndContext>
+            );
+        });
+
+        expect(screen.getByText(message)).toBeInTheDocument();
+
+        act(() => vi.advanceTimersByTime(4000));
+
+        expect(screen.queryByText(message)).not.toBeInTheDocument();
+    });
+});

--- a/src/components/Panels/DragNDrop/SortableCategory.test.tsx
+++ b/src/components/Panels/DragNDrop/SortableCategory.test.tsx
@@ -26,12 +26,16 @@ function segment(id: string): Segment {
     };
 }
 
-function renderCategory(durationHint: string | null) {
-    return render(
+function tree(durationHint: string | null) {
+    return (
         <DndContext>
             <SortableCategory category={segment('seg-1')} visible={true} idActiveItem={null} durationHint={durationHint} />
         </DndContext>
     );
+}
+
+function renderCategory(durationHint: string | null) {
+    return render(tree(durationHint));
 }
 
 describe('SortableCategory surbrillance durée', () => {
@@ -39,7 +43,8 @@ describe('SortableCategory surbrillance durée', () => {
     afterEach(() => vi.useRealTimers());
 
     it('transmet le hint au header pour la surbrillance', () => {
-        renderCategory('Segment trop long');
+        const { rerender } = renderCategory('Segment trop long');
+        rerender(tree('Segment trop long'));
 
         expect(screen.getByTestId('header')).toHaveAttribute('data-hint', 'Segment trop long');
     });
@@ -67,5 +72,26 @@ describe('SortableCategory surbrillance durée', () => {
         act(() => vi.advanceTimersByTime(4000));
 
         expect(screen.queryByText(message)).not.toBeInTheDocument();
+    });
+
+    it('masque le message quand le segment repasse dans les bornes', () => {
+        const message = 'Segment trop long : 5h00 (max 4h)';
+        const { rerender } = renderCategory(null);
+
+        act(() => rerender(tree(message)));
+        expect(screen.getByText(message)).toBeInTheDocument();
+
+        act(() => rerender(tree(null)));
+        expect(screen.queryByText(message)).not.toBeInTheDocument();
+    });
+
+    it('n\'affiche pas de header pour un segment de début/fin et gère durationHint omis', () => {
+        render(
+            <DndContext>
+                <SortableCategory category={{ ...segment('end'), isStartEnd: true }} visible={true} idActiveItem={null} />
+            </DndContext>
+        );
+
+        expect(screen.queryByTestId('header')).not.toBeInTheDocument();
     });
 });

--- a/src/components/Panels/DragNDrop/SortableCategory.tsx
+++ b/src/components/Panels/DragNDrop/SortableCategory.tsx
@@ -27,7 +27,7 @@ function SegmentDurationAlert({ message }: Readonly<{ message: string }>) {
         return null;
     }
 
-    return <div className={"segment-duration-alert"} role={"status"}>{message}</div>;
+    return <output className={"segment-duration-alert"}>{message}</output>;
 }
 
 type Props = {
@@ -44,7 +44,7 @@ type Props = {
  * @param idActiveItem ID de la potentielle étape active
  * @param durationHint message si la durée du segment sort des bornes, sinon null
  */
-export default function SortableCategory({ category, visible, idActiveItem, durationHint = null}: Props) {
+export default function SortableCategory({ category, visible, idActiveItem, durationHint = null}: Readonly<Props>) {
     const [previousHint, setPreviousHint] = useState<string | null>(durationHint);
     const [flashId, setFlashId] = useState(0);
 

--- a/src/components/Panels/DragNDrop/SortableCategory.tsx
+++ b/src/components/Panels/DragNDrop/SortableCategory.tsx
@@ -1,4 +1,5 @@
 import { SortableContext, verticalListSortingStrategy} from "@dnd-kit/sortable";
+import { useEffect, useState } from "react";
 import SortableStepHeader from "./SortableStepHeader.tsx";
 import SortablePDP from "./SortablePDP.tsx";
 import type {Segment, Step} from "../../../customObject/Itinerary/types.ts";
@@ -7,10 +8,33 @@ import {itineraryModel} from "../../../customObject/Itinerary/ItineraryStore.ts"
 import {TimeSpan} from "../../../customObject/TimeSpan.ts";
 import {requestSearchForStep} from "../../../customObject/Search/SearchIntentStore.ts";
 
+const DURATION_ALERT_DURATION_MS = 4000;
+
+/**
+ * Message temporaire signalant une durée de segment hors bornes. Il se masque
+ * seul après quelques secondes ; on le remonte via une `key` pour rejouer
+ * l'alerte à chaque nouveau dépassement.
+ */
+function SegmentDurationAlert({ message }: Readonly<{ message: string }>) {
+    const [visible, setVisible] = useState(true);
+
+    useEffect(() => {
+        const timer = setTimeout(() => setVisible(false), DURATION_ALERT_DURATION_MS);
+        return () => clearTimeout(timer);
+    }, []);
+
+    if (!visible) {
+        return null;
+    }
+
+    return <div className={"segment-duration-alert"} role={"status"}>{message}</div>;
+}
+
 type Props = {
     category: Segment,
     visible: boolean,
     idActiveItem: string  | null,
+    durationHint?: string | null,
 }
 
 /**
@@ -18,8 +42,18 @@ type Props = {
  * @param category objet snapshot du segment
  * @param visible visibilité du segment
  * @param idActiveItem ID de la potentielle étape active
+ * @param durationHint message si la durée du segment sort des bornes, sinon null
  */
-export default function SortableCategory({ category, visible, idActiveItem}: Props) {
+export default function SortableCategory({ category, visible, idActiveItem, durationHint = null}: Props) {
+    const [previousHint, setPreviousHint] = useState<string | null>(durationHint);
+    const [flashId, setFlashId] = useState(0);
+
+    if (durationHint !== previousHint) {
+        setPreviousHint(durationHint);
+        if (durationHint) {
+            setFlashId((id) => id + 1);
+        }
+    }
 
     function handleNewStep()
     {
@@ -60,7 +94,10 @@ export default function SortableCategory({ category, visible, idActiveItem}: Pro
             className={"category-box"}
             style={{opacity: visible ? 1 : 0}}
         >
-            { !category.isStartEnd ? <SortableStepHeader category={category} model={itineraryModel} /> : <></> }
+            { !category.isStartEnd ? <SortableStepHeader category={category} model={itineraryModel} durationHint={durationHint} /> : <></> }
+            { durationHint && flashId > 0 && (
+                <SegmentDurationAlert key={flashId} message={durationHint} />
+            )}
             { category.id == "end" ?
                 <button
                     type="button"

--- a/src/components/Panels/DragNDrop/SortableStepHeader.test.tsx
+++ b/src/components/Panels/DragNDrop/SortableStepHeader.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import type { Segment } from '../../../customObject/Itinerary/types';
+import type ItineraryModel from '../../../customObject/Itinerary/ItineraryModel';
+import { TimeSpan } from '../../../customObject/TimeSpan';
+
+vi.mock('../Item.tsx', () => ({ default: () => <div data-testid="item" /> }));
+vi.mock('../SubTitleWHour.tsx', () => ({ default: () => <div data-testid="subtitle" /> }));
+vi.mock('../../../customObject/Itinerary/ItineraryModel.ts', () => ({ default: class {} }));
+
+import SortableStepHeader from './SortableStepHeader';
+
+const category: Segment = {
+    id: 'seg-1',
+    isStartEnd: false,
+    content: { title: 'Segment 1', hour: new Date(), duration: new TimeSpan(), distance: 0 },
+    steps: [],
+};
+
+const model = {} as unknown as ItineraryModel;
+
+function renderHeader(durationHint: string | null) {
+    return render(
+        <DndContext>
+            <SortableContext items={[category.id]}>
+                <SortableStepHeader category={category} model={model} durationHint={durationHint} />
+            </SortableContext>
+        </DndContext>
+    );
+}
+
+describe('SortableStepHeader', () => {
+    it('marque le header en rouge et pose un tooltip quand la durée est hors bornes', () => {
+        const { container } = renderHeader('Segment 1 trop long : 5h00 (max 4h)');
+
+        const header = container.querySelector('.StepHeader');
+        expect(header).toHaveClass('invalid');
+        expect(header).toHaveAttribute('aria-invalid', 'true');
+        expect(header).toHaveAttribute('title', 'Segment 1 trop long : 5h00 (max 4h)');
+    });
+
+    it('ne marque pas le header quand la durée est valide', () => {
+        const { container } = renderHeader(null);
+
+        const header = container.querySelector('.StepHeader');
+        expect(header).not.toHaveClass('invalid');
+        expect(header).not.toHaveAttribute('aria-invalid');
+        expect(header).not.toHaveAttribute('title');
+    });
+});

--- a/src/components/Panels/DragNDrop/SortableStepHeader.test.tsx
+++ b/src/components/Panels/DragNDrop/SortableStepHeader.test.tsx
@@ -21,8 +21,8 @@ const category: Segment = {
 
 const model = {} as unknown as ItineraryModel;
 
-function renderHeader(durationHint: string | null) {
-    return render(
+function tree(durationHint: string | null) {
+    return (
         <DndContext>
             <SortableContext items={[category.id]}>
                 <SortableStepHeader category={category} model={model} durationHint={durationHint} />
@@ -33,20 +33,35 @@ function renderHeader(durationHint: string | null) {
 
 describe('SortableStepHeader', () => {
     it('marque le header en rouge et pose un tooltip quand la durée est hors bornes', () => {
-        const { container } = renderHeader('Segment 1 trop long : 5h00 (max 4h)');
+        const hint = 'Segment 1 trop long : 5h00 (max 4h)';
+        const { container, rerender } = render(tree(hint));
+        rerender(tree(hint));
 
         const header = container.querySelector('.StepHeader');
         expect(header).toHaveClass('invalid');
         expect(header).toHaveAttribute('aria-invalid', 'true');
-        expect(header).toHaveAttribute('title', 'Segment 1 trop long : 5h00 (max 4h)');
+        expect(header).toHaveAttribute('title', hint);
     });
 
     it('ne marque pas le header quand la durée est valide', () => {
-        const { container } = renderHeader(null);
+        const { container, rerender } = render(tree(null));
+        rerender(tree(null));
 
         const header = container.querySelector('.StepHeader');
         expect(header).not.toHaveClass('invalid');
         expect(header).not.toHaveAttribute('aria-invalid');
         expect(header).not.toHaveAttribute('title');
+    });
+
+    it('utilise la valeur par défaut quand durationHint est omis', () => {
+        const { container } = render(
+            <DndContext>
+                <SortableContext items={[category.id]}>
+                    <SortableStepHeader category={category} model={model} />
+                </SortableContext>
+            </DndContext>
+        );
+
+        expect(container.querySelector('.StepHeader')).not.toHaveClass('invalid');
     });
 });

--- a/src/components/Panels/DragNDrop/SortableStepHeader.tsx
+++ b/src/components/Panels/DragNDrop/SortableStepHeader.tsx
@@ -5,7 +5,7 @@ import SubTitleWHour from "../SubTitleWHour.tsx";
 import ItineraryModel from "../../../customObject/Itinerary/ItineraryModel.ts";
 import Item from "../Item.tsx";
 
-export default function SortableStepHeader({category, model} : {category: Segment, model: ItineraryModel}) {
+export default function SortableStepHeader({category, model, durationHint = null} : {category: Segment, model: ItineraryModel, durationHint?: string | null}) {
     const { attributes, listeners, setNodeRef, transform, transition } =
         useSortable({
             id: category.id,
@@ -16,7 +16,9 @@ export default function SortableStepHeader({category, model} : {category: Segmen
         <div
             ref={setNodeRef}
             style={{ transform: CSS.Translate.toString(transform), transition }}
-            className={"StepHeader"}
+            className={durationHint ? "StepHeader invalid" : "StepHeader"}
+            aria-invalid={durationHint ? true : undefined}
+            title={durationHint ?? undefined}
             {...attributes}
             {...listeners}
         >

--- a/src/components/Panels/DragNDrop/StepList.test.tsx
+++ b/src/components/Panels/DragNDrop/StepList.test.tsx
@@ -47,7 +47,8 @@ function itineraryWith(segments: Segment[]): Itinerary {
 describe('StepList pause lines', () => {
     it('affiche une ligne pause pour chaque segment avec une pause', () => {
         mockItinerary = itineraryWith([segment('seg-1', 30 * 60), segment('seg-2', 0)]);
-        render(<StepList />);
+        const { rerender } = render(<StepList />);
+        rerender(<StepList />);
 
         expect(screen.getAllByText('Pause')).toHaveLength(1);
         expect(screen.getByText('0H 30MIN')).toBeInTheDocument();

--- a/src/components/Panels/DragNDrop/StepList.tsx
+++ b/src/components/Panels/DragNDrop/StepList.tsx
@@ -20,12 +20,20 @@ import PauseLine from "./PauseLine.tsx";
 import {type DndProps, useDragNDrop} from "./UseDragNDrop.tsx";
 import {useItinerary} from "../../../customObject/Itinerary/UseItinerary.ts";
 import {itineraryModel} from "../../../customObject/Itinerary/ItineraryStore.ts";
+import {useSegmentDurationBounds} from "../../../customObject/Itinerary/useSegmentDurationBounds.ts";
+import {buildSegmentDurationHint, getSegmentDurationViolation} from "../../../customObject/Itinerary/segmentDurationValidation.ts";
 
 /**
  * Contient toute la partie DragNDrop sur les segments, et les étapes
  */
 export default function StepList() {
     const itinerary: Itinerary = useItinerary(itineraryModel.store);
+    const bounds = useSegmentDurationBounds(itinerary);
+
+    const durationHintFor = (segment: Segment): string | null => {
+        const violation = getSegmentDurationViolation(segment, bounds);
+        return violation ? buildSegmentDurationHint(violation, bounds) : null;
+    };
 
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
@@ -49,6 +57,7 @@ export default function StepList() {
                             visible={!(cat.id == dnd.activeCat?.id)}
                             category={cat}
                             idActiveItem={dnd.activeItem?.id ? dnd.activeItem.id : null}
+                            durationHint={durationHintFor(cat)}
                         />
                         {!cat.isStartEnd && (cat.content.breakDuration ?? 0) > 0 && (
                             <PauseLine durationSeconds={cat.content.breakDuration ?? 0} />
@@ -68,7 +77,8 @@ export default function StepList() {
                     <SortableCategory
                         visible={true}
                         category={dnd.activeCat}
-                        idActiveItem={null} />
+                        idActiveItem={null}
+                        durationHint={durationHintFor(dnd.activeCat)} />
                 ) : null}
             </DragOverlay>
         </DndContext>

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -118,12 +118,13 @@ h1, .title {
 }
 
 .segment-duration-alert {
+    display: block;
     margin: 4px 0 2px;
     padding: 6px 10px;
     border-radius: 8px;
-    background: rgba(217, 45, 32, 0.12);
+    background: #fbe9e7;
     border: 1px solid rgba(217, 45, 32, 0.4);
-    color: #b42318;
+    color: #8a1510;
     font-family: 'Montserrat', sans-serif;
     font-size: clamp(9px, 1.6vw, 12px);
     font-weight: 600;

--- a/src/components/Panels/Panels.css
+++ b/src/components/Panels/Panels.css
@@ -110,6 +110,39 @@ h1, .title {
     background: rgba(255, 255, 255, 0.35);
 }
 
+.StepHeader.invalid {
+    outline: 2px solid #d92d20;
+    outline-offset: -2px;
+    border-radius: 8px;
+    background: rgba(217, 45, 32, 0.08);
+}
+
+.segment-duration-alert {
+    margin: 4px 0 2px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: rgba(217, 45, 32, 0.12);
+    border: 1px solid rgba(217, 45, 32, 0.4);
+    color: #b42318;
+    font-family: 'Montserrat', sans-serif;
+    font-size: clamp(9px, 1.6vw, 12px);
+    font-weight: 600;
+    line-height: 1.3;
+    pointer-events: none;
+    animation: segment-duration-alert-in 150ms ease;
+}
+
+@keyframes segment-duration-alert-in {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .item {
     display: flex;
     align-items: center;

--- a/src/customObject/Itinerary/segmentDurationValidation.test.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
-    buildSegmentDurationErrorMessage,
+    buildSegmentDurationHint,
     findSegmentDurationViolations,
+    getSegmentDurationViolation,
 } from "./segmentDurationValidation.ts";
 import type { Itinerary, Segment } from "./types.ts";
 import type { GlobalSettings } from "../../components/SettingsModal/settingsTypes.ts";
@@ -41,6 +42,35 @@ const bounds: Pick<GlobalSettings, "minSegmentDuration" | "maxSegmentDuration"> 
     maxSegmentDuration: 4,
 };
 
+describe("getSegmentDurationViolation", () => {
+    it("retourne null quand la durée est dans les bornes", () => {
+        expect(getSegmentDurationViolation(makeSegment("a", 2), bounds)).toBeNull();
+    });
+
+    it("retourne null pour un segment exactement aux bornes", () => {
+        expect(getSegmentDurationViolation(makeSegment("a", 1), bounds)).toBeNull();
+        expect(getSegmentDurationViolation(makeSegment("b", 4), bounds)).toBeNull();
+    });
+
+    it("signale un segment trop court", () => {
+        const violation = getSegmentDurationViolation(makeSegment("a", 0.5), bounds);
+
+        expect(violation?.kind).toBe("min");
+        expect(violation?.durationLabel).toBe("0h30");
+    });
+
+    it("signale un segment trop long", () => {
+        const violation = getSegmentDurationViolation(makeSegment("a", 5), bounds);
+
+        expect(violation?.kind).toBe("max");
+    });
+
+    it("ignore les segments de départ/arrivée", () => {
+        expect(getSegmentDurationViolation(makeSegment("start", 0, { isStartEnd: true }), bounds)).toBeNull();
+        expect(getSegmentDurationViolation(makeSegment("end", 0), bounds)).toBeNull();
+    });
+});
+
 describe("findSegmentDurationViolations", () => {
     it("ne retourne aucune violation quand tous les segments sont dans les bornes", () => {
         const itinerary = makeItinerary([makeSegment("a", 2), makeSegment("b", 3.5)]);
@@ -48,50 +78,29 @@ describe("findSegmentDurationViolations", () => {
         expect(findSegmentDurationViolations(itinerary, bounds)).toEqual([]);
     });
 
-    it("signale un segment trop court", () => {
-        const itinerary = makeItinerary([makeSegment("a", 0.5)]);
+    it("recense chaque segment hors bornes", () => {
+        const itinerary = makeItinerary([makeSegment("a", 0.5), makeSegment("b", 2), makeSegment("c", 6)]);
 
         const violations = findSegmentDurationViolations(itinerary, bounds);
 
-        expect(violations).toHaveLength(1);
-        expect(violations[0].kind).toBe("min");
-        expect(violations[0].durationLabel).toBe("0h30");
-    });
-
-    it("signale un segment trop long", () => {
-        const itinerary = makeItinerary([makeSegment("a", 5)]);
-
-        const violations = findSegmentDurationViolations(itinerary, bounds);
-
-        expect(violations).toHaveLength(1);
-        expect(violations[0].kind).toBe("max");
-    });
-
-    it("accepte les segments exactement aux bornes", () => {
-        const itinerary = makeItinerary([makeSegment("a", 1), makeSegment("b", 4)]);
-
-        expect(findSegmentDurationViolations(itinerary, bounds)).toEqual([]);
-    });
-
-    it("ignore les segments de départ/arrivée", () => {
-        const itinerary = makeItinerary([
-            makeSegment("start", 0, { isStartEnd: true }),
-            makeSegment("end", 0, { isStartEnd: true }),
-        ]);
-
-        expect(findSegmentDurationViolations(itinerary, bounds)).toEqual([]);
+        expect(violations).toHaveLength(2);
+        expect(violations.map((v) => v.kind)).toEqual(["min", "max"]);
     });
 });
 
-describe("buildSegmentDurationErrorMessage", () => {
-    it("mentionne le nom du segment et la borne dépassée", () => {
-        const itinerary = makeItinerary([makeSegment("a", 5)]);
-        const violations = findSegmentDurationViolations(itinerary, bounds);
+describe("buildSegmentDurationHint", () => {
+    it("mentionne la durée et la borne max quand le segment est trop long", () => {
+        const violation = getSegmentDurationViolation(makeSegment("a", 5), bounds)!;
 
-        const message = buildSegmentDurationErrorMessage(violations, bounds);
+        expect(buildSegmentDurationHint(violation, bounds)).toBe(
+            "« Segment a » trop long : 5h00 (max 4h)"
+        );
+    });
 
-        expect(message).toContain("Segment a");
-        expect(message).toContain("maximum de 4h");
-        expect(message).toContain("Impossible d'enregistrer");
+    it("mentionne la borne min quand le segment est trop court", () => {
+        const violation = getSegmentDurationViolation(makeSegment("a", 0.5), bounds)!;
+
+        expect(buildSegmentDurationHint(violation, bounds)).toContain("trop court");
+        expect(buildSegmentDurationHint(violation, bounds)).toContain("min 1h");
     });
 });

--- a/src/customObject/Itinerary/segmentDurationValidation.test.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
     buildSegmentDurationHint,
-    findSegmentDurationViolations,
     getSegmentDurationViolation,
 } from "./segmentDurationValidation.ts";
-import type { Itinerary, Segment } from "./types.ts";
+import type { Segment } from "./types.ts";
 import type { GlobalSettings } from "../../components/SettingsModal/settingsTypes.ts";
 import { TimeSpan } from "../TimeSpan.ts";
 
@@ -22,18 +21,6 @@ function makeSegment(id: string, hours: number, overrides: Partial<Segment> = {}
             distance: 0,
         },
         ...overrides,
-    };
-}
-
-function makeItinerary(segments: Segment[]): Itinerary {
-    return {
-        id: 1,
-        name: "Convoi",
-        shareCode: "",
-        totalDuration: new TimeSpan(),
-        totalDistance: 0,
-        segments,
-        draft: true,
     };
 }
 
@@ -68,23 +55,6 @@ describe("getSegmentDurationViolation", () => {
     it("ignore les segments de départ/arrivée", () => {
         expect(getSegmentDurationViolation(makeSegment("start", 0, { isStartEnd: true }), bounds)).toBeNull();
         expect(getSegmentDurationViolation(makeSegment("end", 0), bounds)).toBeNull();
-    });
-});
-
-describe("findSegmentDurationViolations", () => {
-    it("ne retourne aucune violation quand tous les segments sont dans les bornes", () => {
-        const itinerary = makeItinerary([makeSegment("a", 2), makeSegment("b", 3.5)]);
-
-        expect(findSegmentDurationViolations(itinerary, bounds)).toEqual([]);
-    });
-
-    it("recense chaque segment hors bornes", () => {
-        const itinerary = makeItinerary([makeSegment("a", 0.5), makeSegment("b", 2), makeSegment("c", 6)]);
-
-        const violations = findSegmentDurationViolations(itinerary, bounds);
-
-        expect(violations).toHaveLength(2);
-        expect(violations.map((v) => v.kind)).toEqual(["min", "max"]);
     });
 });
 

--- a/src/customObject/Itinerary/segmentDurationValidation.test.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.test.ts
@@ -52,6 +52,13 @@ describe("getSegmentDurationViolation", () => {
         expect(violation?.kind).toBe("max");
     });
 
+    it("nomme un segment sans titre", () => {
+        const segment = makeSegment("a", 5);
+        segment.content.title = "";
+
+        expect(getSegmentDurationViolation(segment, bounds)?.segmentName).toBe("Segment sans nom");
+    });
+
     it("ignore les segments de départ/arrivée", () => {
         expect(getSegmentDurationViolation(makeSegment("start", 0, { isStartEnd: true }), bounds)).toBeNull();
         expect(getSegmentDurationViolation(makeSegment("end", 0), bounds)).toBeNull();

--- a/src/customObject/Itinerary/segmentDurationValidation.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.ts
@@ -1,4 +1,4 @@
-import type { Itinerary, Segment } from "./types.ts";
+import type { Segment } from "./types.ts";
 import type { GlobalSettings } from "../../components/SettingsModal/settingsTypes.ts";
 import { TimeSpan } from "../TimeSpan.ts";
 
@@ -51,21 +51,6 @@ export function getSegmentDurationViolation(
         durationLabel: formatDurationLabel(segment.content.duration),
         kind: hours < bounds.minSegmentDuration ? "min" : "max",
     };
-}
-
-/**
- * Recense tous les segments de l'itinéraire dont la durée sort des bornes.
- * @param itinerary itinéraire à contrôler
- * @param bounds durées min et max autorisées, en heures
- */
-export function findSegmentDurationViolations(
-    itinerary: Itinerary,
-    bounds: SegmentDurationBounds
-): SegmentDurationViolation[] {
-    return itinerary.segments.flatMap((segment): SegmentDurationViolation[] => {
-        const violation = getSegmentDurationViolation(segment, bounds);
-        return violation ? [violation] : [];
-    });
 }
 
 /**

--- a/src/customObject/Itinerary/segmentDurationValidation.ts
+++ b/src/customObject/Itinerary/segmentDurationValidation.ts
@@ -27,8 +27,34 @@ function formatDurationLabel(duration?: TimeSpan): string {
 }
 
 /**
- * Recense les segments dont la durée sort des bornes min/max définies dans les
- * paramètres globaux. Les segments de départ/arrivée sont ignorés.
+ * Contrôle la durée d'un segment contre les bornes min/max des paramètres
+ * globaux. Renvoie `null` si la durée respecte les bornes ou s'il s'agit d'un
+ * segment de départ/arrivée.
+ * @param segment segment à contrôler
+ * @param bounds durées min et max autorisées, en heures
+ */
+export function getSegmentDurationViolation(
+    segment: Segment,
+    bounds: SegmentDurationBounds
+): SegmentDurationViolation | null {
+    if (!isCheckableSegment(segment)) {
+        return null;
+    }
+
+    const hours = normalizeDuration(segment.content.duration).duration / MS_PER_HOUR;
+    if (hours >= bounds.minSegmentDuration && hours <= bounds.maxSegmentDuration) {
+        return null;
+    }
+
+    return {
+        segmentName: segment.content.title || "Segment sans nom",
+        durationLabel: formatDurationLabel(segment.content.duration),
+        kind: hours < bounds.minSegmentDuration ? "min" : "max",
+    };
+}
+
+/**
+ * Recense tous les segments de l'itinéraire dont la durée sort des bornes.
  * @param itinerary itinéraire à contrôler
  * @param bounds durées min et max autorisées, en heures
  */
@@ -36,41 +62,22 @@ export function findSegmentDurationViolations(
     itinerary: Itinerary,
     bounds: SegmentDurationBounds
 ): SegmentDurationViolation[] {
-    const { minSegmentDuration, maxSegmentDuration } = bounds;
-
-    return itinerary.segments.filter(isCheckableSegment).flatMap((segment): SegmentDurationViolation[] => {
-        const hours = normalizeDuration(segment.content.duration).duration / MS_PER_HOUR;
-        const segmentName = segment.content.title || "Segment sans nom";
-        const durationLabel = formatDurationLabel(segment.content.duration);
-
-        if (hours < minSegmentDuration) {
-            return [{ segmentName, durationLabel, kind: "min" }];
-        }
-        if (hours > maxSegmentDuration) {
-            return [{ segmentName, durationLabel, kind: "max" }];
-        }
-        return [];
+    return itinerary.segments.flatMap((segment): SegmentDurationViolation[] => {
+        const violation = getSegmentDurationViolation(segment, bounds);
+        return violation ? [violation] : [];
     });
 }
 
 /**
- * Construit le message d'erreur affiché lorsqu'un ou plusieurs segments ne
- * respectent pas les bornes de durée.
- * @param violations segments hors bornes
+ * Construit le message court affiché à côté d'un segment hors bornes.
+ * @param violation segment hors bornes
  * @param bounds durées min et max autorisées, en heures
  */
-export function buildSegmentDurationErrorMessage(
-    violations: SegmentDurationViolation[],
+export function buildSegmentDurationHint(
+    violation: SegmentDurationViolation,
     bounds: SegmentDurationBounds
 ): string {
-    const details = violations
-        .map((violation) => {
-            const bound = violation.kind === "min"
-                ? `en dessous du minimum de ${bounds.minSegmentDuration}h`
-                : `au-dessus du maximum de ${bounds.maxSegmentDuration}h`;
-            return `« ${violation.segmentName} » (${violation.durationLabel}) est ${bound}`;
-        })
-        .join(" ; ");
-
-    return `Impossible d'enregistrer : ${details}.`;
+    return violation.kind === "min"
+        ? `« ${violation.segmentName} » trop court : ${violation.durationLabel} (min ${bounds.minSegmentDuration}h)`
+        : `« ${violation.segmentName} » trop long : ${violation.durationLabel} (max ${bounds.maxSegmentDuration}h)`;
 }

--- a/src/customObject/Itinerary/useSegmentDurationBounds.test.ts
+++ b/src/customObject/Itinerary/useSegmentDurationBounds.test.ts
@@ -48,6 +48,9 @@ describe("useSegmentDurationBounds", () => {
         rerender();
 
         expect(result.current).toEqual({ minSegmentDuration: 1, maxSegmentDuration: 3 });
+
+        rerender();
+        expect(result.current).toEqual({ minSegmentDuration: 1, maxSegmentDuration: 3 });
     });
 
     it("ignore une valeur stockée invalide", () => {

--- a/src/customObject/Itinerary/useSegmentDurationBounds.test.ts
+++ b/src/customObject/Itinerary/useSegmentDurationBounds.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { Itinerary } from "./types";
+
+const { getGlobalSettingsStorageValue, subscribeToGlobalSettingsChanges, createDefaultGlobalSettings } = vi.hoisted(() => ({
+    getGlobalSettingsStorageValue: vi.fn<() => string | null>(() => null),
+    subscribeToGlobalSettingsChanges: vi.fn(() => () => undefined),
+    createDefaultGlobalSettings: vi.fn(() => ({ minSegmentDuration: 1, maxSegmentDuration: 4 })),
+}));
+vi.mock("../../components/SettingsModal/settingsStorage", () => ({
+    getGlobalSettingsStorageValue,
+    subscribeToGlobalSettingsChanges,
+    createDefaultGlobalSettings,
+}));
+
+import { useSegmentDurationBounds } from "./useSegmentDurationBounds";
+
+const itinerary = { id: 1, segments: [] } as unknown as Itinerary;
+
+describe("useSegmentDurationBounds", () => {
+    beforeEach(() => {
+        getGlobalSettingsStorageValue.mockReturnValue(null);
+    });
+
+    it("dérive les bornes des paramètres stockés", () => {
+        getGlobalSettingsStorageValue.mockReturnValue(JSON.stringify({ minSegmentDuration: 2, maxSegmentDuration: 5 }));
+
+        const { result } = renderHook(() => useSegmentDurationBounds(itinerary));
+
+        expect(result.current).toEqual({ minSegmentDuration: 2, maxSegmentDuration: 5 });
+        expect(subscribeToGlobalSettingsChanges).toHaveBeenCalled();
+    });
+
+    it("retombe sur les valeurs par défaut sans paramètres stockés", () => {
+        getGlobalSettingsStorageValue.mockReturnValue(null);
+
+        const { result } = renderHook(() => useSegmentDurationBounds(itinerary));
+
+        expect(result.current).toEqual({ minSegmentDuration: 1, maxSegmentDuration: 4 });
+    });
+
+    it("recalcule quand la valeur stockée change", () => {
+        getGlobalSettingsStorageValue.mockReturnValue(JSON.stringify({ minSegmentDuration: 2, maxSegmentDuration: 5 }));
+        const { result, rerender } = renderHook(() => useSegmentDurationBounds(itinerary));
+        expect(result.current).toEqual({ minSegmentDuration: 2, maxSegmentDuration: 5 });
+
+        getGlobalSettingsStorageValue.mockReturnValue(JSON.stringify({ minSegmentDuration: 1, maxSegmentDuration: 3 }));
+        rerender();
+
+        expect(result.current).toEqual({ minSegmentDuration: 1, maxSegmentDuration: 3 });
+    });
+
+    it("ignore une valeur stockée invalide", () => {
+        getGlobalSettingsStorageValue.mockReturnValue("{pas du json");
+
+        const { result } = renderHook(() => useSegmentDurationBounds(itinerary));
+
+        expect(result.current).toEqual({ minSegmentDuration: 1, maxSegmentDuration: 4 });
+    });
+});

--- a/src/customObject/Itinerary/useSegmentDurationBounds.ts
+++ b/src/customObject/Itinerary/useSegmentDurationBounds.ts
@@ -1,0 +1,24 @@
+import { useSyncExternalStore } from "react";
+import type { Itinerary } from "./types.ts";
+import type { SegmentDurationBounds } from "./segmentDurationValidation.ts";
+import {
+    getGlobalSettingsStorageValue,
+    loadGlobalSettings,
+    subscribeToGlobalSettingsChanges,
+} from "../../components/SettingsModal/settingsStorage.ts";
+
+/**
+ * Expose les bornes de durée de segment (min/max) des paramètres globaux et
+ * force un recalcul quand ces paramètres changent, y compris depuis un autre
+ * onglet.
+ * @param itinerary itinéraire courant (les paramètres sont stockés par itinéraire)
+ */
+export function useSegmentDurationBounds(itinerary: Itinerary): SegmentDurationBounds {
+    useSyncExternalStore(
+        subscribeToGlobalSettingsChanges,
+        () => getGlobalSettingsStorageValue(itinerary.id)
+    );
+
+    const { minSegmentDuration, maxSegmentDuration } = loadGlobalSettings(itinerary);
+    return { minSegmentDuration, maxSegmentDuration };
+}

--- a/src/customObject/Itinerary/useSegmentDurationBounds.ts
+++ b/src/customObject/Itinerary/useSegmentDurationBounds.ts
@@ -1,24 +1,42 @@
-import { useSyncExternalStore } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import type { Itinerary } from "./types.ts";
 import type { SegmentDurationBounds } from "./segmentDurationValidation.ts";
+import type { GlobalSettings } from "../../components/SettingsModal/settingsTypes.ts";
 import {
+    createDefaultGlobalSettings,
     getGlobalSettingsStorageValue,
-    loadGlobalSettings,
     subscribeToGlobalSettingsChanges,
 } from "../../components/SettingsModal/settingsStorage.ts";
+
+function parseStoredSettings(raw: string | null): GlobalSettings | null {
+    if (!raw) {
+        return null;
+    }
+    try {
+        return JSON.parse(raw) as GlobalSettings;
+    } catch {
+        return null;
+    }
+}
 
 /**
  * Expose les bornes de durée de segment (min/max) des paramètres globaux et
  * force un recalcul quand ces paramètres changent, y compris depuis un autre
- * onglet.
+ * onglet. Les bornes sont dérivées de la valeur stockée pour rester réactives
+ * malgré la mémoïsation automatique (React Compiler).
  * @param itinerary itinéraire courant (les paramètres sont stockés par itinéraire)
  */
 export function useSegmentDurationBounds(itinerary: Itinerary): SegmentDurationBounds {
-    useSyncExternalStore(
+    const raw = useSyncExternalStore(
         subscribeToGlobalSettingsChanges,
         () => getGlobalSettingsStorageValue(itinerary.id)
     );
 
-    const { minSegmentDuration, maxSegmentDuration } = loadGlobalSettings(itinerary);
-    return { minSegmentDuration, maxSegmentDuration };
+    return useMemo(() => {
+        const settings = parseStoredSettings(raw) ?? createDefaultGlobalSettings(itinerary);
+        return {
+            minSegmentDuration: settings.minSegmentDuration,
+            maxSegmentDuration: settings.maxSegmentDuration,
+        };
+    }, [raw, itinerary]);
 }


### PR DESCRIPTION
## Contexte

Remplace le contrôle **bloquant à la sauvegarde** (toast + save refusé, introduit en #164) par un signalement **réactif et non bloquant** dans le panneau de configuration à gauche, conformément au retour utilisateur.

## Comportement

- Dès qu'un segment est modifié (ou que les bornes min/max des paramètres globaux changent), sa durée est comparée aux limites.
- Si elle sort des bornes : le **header du segment est surligné en rouge** (persistant tant que la durée est invalide), sans gêner le drag-n-drop (`outline`, aucun impact sur le layout).
- Un **message transitoire** (« … trop long : 5h00 (max 4h) ») s'affiche quelques secondes sous le segment concerné au moment où il devient hors bornes.
- La sauvegarde n'est plus bloquée.

## Implémentation

- `segmentDurationValidation.ts` : ajout de `getSegmentDurationViolation` (contrôle par segment) et `buildSegmentDurationHint` (message court) ; `findSegmentDurationViolations` réutilise le contrôle par segment.
- `useSegmentDurationBounds` : hook `useSyncExternalStore` qui relit les bornes et se réabonne aux changements de paramètres globaux (multi-onglets inclus).
- `StepList` calcule le hint par segment ; `SortableCategory` gère le message transitoire (auto-dismiss via sous-composant, pas de flash au montage) ; `SortableStepHeader` applique la classe `invalid` + tooltip natif.
- `ActionButtons` : retrait du garde bloquant et du toast à la sauvegarde.

## Tests

- Unitaires : `getSegmentDurationViolation` (dans/hors bornes, aux bornes, départ/arrivée), `findSegmentDurationViolations`, `buildSegmentDurationHint`.
- Composant : `SortableCategory` transmet le hint (surbrillance), n'affiche pas de message au montage, affiche puis masque le message transitoire.
- `ActionButtons` : sauvegarde de nouveau inconditionnelle.
- Suite complète verte (351 tests).